### PR TITLE
Revert minimum Go version to 1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,18 +7,22 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 jobs:
   build:
+    strategy:
+      matrix:
+        go-version: ["1.20", "stable"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: ${{ matrix.go-version }}
+
+      - run: go version
 
       - name: Build
         run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/jedisct1/go-ipcrypt
 
-go 1.23.0
+go 1.21
+
+require (
+	golang.org/x/crypto v0.17.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
 module github.com/jedisct1/go-ipcrypt
 
-go 1.21
-
-require (
-	golang.org/x/crypto v0.17.0
-)
+go 1.20

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -10,7 +10,6 @@ package ipcrypt
 import (
 	"crypto/aes"
 	"crypto/rand"
-	"crypto/subtle"
 	"errors"
 	"fmt"
 	"net"
@@ -72,7 +71,9 @@ func xorBytes(a, b []byte) []byte {
 		return nil
 	}
 	c := make([]byte, len(a))
-	subtle.XORBytes(c, a, b)
+	for i := range a {
+		c[i] = a[i] ^ b[i]
+	}
 	return c
 }
 

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -10,6 +10,7 @@ package ipcrypt
 import (
 	"crypto/aes"
 	"crypto/rand"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"net"
@@ -71,9 +72,7 @@ func xorBytes(a, b []byte) []byte {
 		return nil
 	}
 	c := make([]byte, len(a))
-	for i := range a {
-		c[i] = a[i] ^ b[i]
-	}
+	subtle.XORBytes(c, a, b)
 	return c
 }
 

--- a/ipcrypt_test.go
+++ b/ipcrypt_test.go
@@ -428,7 +428,7 @@ func TestRandomIPs(t *testing.T) {
 	}
 
 	const numTests = 100
-	for range numTests {
+	for i := 0; i < numTests; i++ {
 		ip := generateRandomIP(t)
 		ipAddr := net.ParseIP(ip)
 		if ipAddr == nil {

--- a/kiasu-bc.go
+++ b/kiasu-bc.go
@@ -92,7 +92,7 @@ var invSbox = [256]byte{
 // gmul performs multiplication in GF(2^8)
 func gmul(a, b byte) byte {
 	var p byte
-	for range 8 {
+	for i := 0; i < 8; i++ {
 		if (b & 1) != 0 {
 			p ^= a
 		}
@@ -255,14 +255,14 @@ func KiasuBCEncrypt(key, tweak, block []byte) ([]byte, error) {
 	copy(state, block)
 
 	// Initial round
-	for i := range 16 {
+	for i := 0; i < 16; i++ {
 		state[i] ^= roundKeys[0][i] ^ paddedTweak[i]
 	}
 
 	// Main rounds
 	for round := 1; round < 10; round++ {
 		// SubBytes
-		for i := range 16 {
+		for i := 0; i < 16; i++ {
 			state[i] = sbox[state[i]]
 		}
 
@@ -273,14 +273,14 @@ func KiasuBCEncrypt(key, tweak, block []byte) ([]byte, error) {
 		mixColumns(state)
 
 		// AddRoundKey
-		for i := range 16 {
+		for i := 0; i < 16; i++ {
 			state[i] ^= roundKeys[round][i] ^ paddedTweak[i]
 		}
 	}
 
 	// Final round
 	// SubBytes
-	for i := range 16 {
+	for i := 0; i < 16; i++ {
 		state[i] = sbox[state[i]]
 	}
 
@@ -288,7 +288,7 @@ func KiasuBCEncrypt(key, tweak, block []byte) ([]byte, error) {
 	shiftRows(state)
 
 	// AddRoundKey
-	for i := range 16 {
+	for i := 0; i < 16; i++ {
 		state[i] ^= roundKeys[10][i] ^ paddedTweak[i]
 	}
 
@@ -316,7 +316,7 @@ func KiasuBCDecrypt(key, tweak, block []byte) ([]byte, error) {
 	copy(state, block)
 
 	// Initial round
-	for i := range 16 {
+	for i := 0; i < 16; i++ {
 		state[i] ^= roundKeys[10][i] ^ paddedTweak[i]
 	}
 
@@ -324,14 +324,14 @@ func KiasuBCDecrypt(key, tweak, block []byte) ([]byte, error) {
 	invShiftRows(state)
 
 	// Inverse SubBytes
-	for i := range 16 {
+	for i := 0; i < 16; i++ {
 		state[i] = invSbox[state[i]]
 	}
 
 	// Main rounds
 	for round := 9; round > 0; round-- {
 		// AddRoundKey
-		for i := range 16 {
+		for i := 0; i < 16; i++ {
 			state[i] ^= roundKeys[round][i] ^ paddedTweak[i]
 		}
 
@@ -342,14 +342,14 @@ func KiasuBCDecrypt(key, tweak, block []byte) ([]byte, error) {
 		invShiftRows(state)
 
 		// Inverse SubBytes
-		for i := range 16 {
+		for i := 0; i < 16; i++ {
 			state[i] = invSbox[state[i]]
 		}
 	}
 
 	// Final round
 	// AddRoundKey
-	for i := range 16 {
+	for i := 0; i < 16; i++ {
 		state[i] ^= roundKeys[0][i] ^ paddedTweak[i]
 	}
 


### PR DESCRIPTION
- Set Go version requirement to 1.20 for debian stable
- Use subtle.XORBytes() instead of a loop
- Update CI to test both go 1.20 and latest stable release version
