### PR TITLE
API modifications to support zero-allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ func main() {
 - `KeySizeNDX`: 32 bytes (ipcrypt-ndx)
 - `TweakSize`: 8 bytes (ipcrypt-nd tweak)
 - `TweakSizeX`: 16 bytes (ipcrypt-ndx tweak)
-- `MaxIPSize`: 16 bytes
-- `NonDeterministicSize`: 24 bytes (`TweakSize + MaxIPSize`)
-- `NonDeterministicXSize`: 32 bytes (`TweakSizeX + MaxIPSize`)
+- `NonDeterministicSize`: 24 bytes (`TweakSize + net.IPv6len`)
+- `NonDeterministicXSize`: 32 bytes (`TweakSizeX + net.IPv6len`)
 
 ### Types
 
@@ -104,26 +103,26 @@ func main() {
 #### Deterministic Mode
 - `EncryptIP(key []byte, ip net.IP) (net.IP, error)` - Encrypts an IP address deterministically
 - `DecryptIP(key []byte, encrypted net.IP) (net.IP, error)` - Decrypts an IP address deterministically
-- `EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation deterministic encryption into a preallocated buffer of at least `MaxIPSize` bytes
-- `DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation deterministic decryption into a preallocated buffer of at least `MaxIPSize` bytes
+- `EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation deterministic encryption into a preallocated buffer of exactly `net.IPv6len` bytes
+- `DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation deterministic decryption into a preallocated buffer of exactly `net.IPv6len` bytes
 
 #### Prefix-Preserving Mode (ipcrypt-pfx)
 - `EncryptIPPfx(ip net.IP, key []byte) (net.IP, error)` - Encrypts an IP address with prefix preservation
 - `DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error)` - Decrypts an IP address with prefix preservation
-- `EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation prefix-preserving encryption into a preallocated buffer of at least `MaxIPSize` bytes
-- `DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation prefix-preserving decryption into a preallocated buffer of at least `MaxIPSize` bytes
+- `EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation prefix-preserving encryption into a preallocated buffer of exactly `net.IPv4len` bytes for IPv4 or exactly `net.IPv6len` bytes for IPv6
+- `DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation prefix-preserving decryption into a preallocated buffer of exactly `net.IPv4len` bytes for IPv4 or exactly `net.IPv6len` bytes for IPv6
 
 #### Non-Deterministic Mode (ipcrypt-nd)
 - `EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, error)` - Encrypts with 8-byte tweak
 - `DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error)` - Decrypts ipcrypt-nd ciphertext
-- `EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error)` - Zero-allocation encryption into a preallocated buffer of at least `NonDeterministicSize` bytes
-- `DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation decryption into a preallocated buffer of at least `MaxIPSize` bytes
+- `EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error)` - Zero-allocation encryption into a preallocated buffer of exactly `NonDeterministicSize` bytes
+- `DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation decryption into a preallocated buffer of exactly `net.IPv6len` bytes
 
 #### Extended Non-Deterministic Mode (ipcrypt-ndx)
 - `EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, error)` - Encrypts with 16-byte tweak
 - `DecryptIPNonDeterministicX(ciphertext []byte, key []byte) (string, error)` - Decrypts ipcrypt-ndx ciphertext
-- `EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error)` - Zero-allocation encryption into a preallocated buffer of at least `NonDeterministicXSize` bytes
-- `DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation decryption into a preallocated buffer of at least `MaxIPSize` bytes
+- `EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error)` - Zero-allocation encryption into a preallocated buffer of exactly `NonDeterministicXSize` bytes
+- `DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation decryption into a preallocated buffer of exactly `net.IPv6len` bytes
 
 ## Zero-Allocation Usage
 
@@ -131,7 +130,7 @@ The `To` functions write into caller-provided buffers and take a reusable `Scrat
 
 ```go
 scratch := ipcrypt.NewScratchPad()
-buf := make([]byte, ipcrypt.MaxIPSize)
+buf := make([]byte, net.IPv6len) // Use net.IPv4len for IPv4-only callers.
 
 for ip := range ips {
     encrypted, err := ipcrypt.EncryptIPPfxTo(ip, key, buf, scratch)
@@ -142,7 +141,9 @@ for ip := range ips {
 }
 ```
 
-Note that the scratch pad must be initialized before use. _Also, you cannot reuse the same scratch pad across different keys._
+Note that the scratch pad must be initialized before use. It is safe to reuse the same scratch pad across different keys, 
+but cached cipher state will be rebuilt when the key changes, so you get the best performance when reusing it with the 
+same key. A `ScratchPad` must not be shared concurrently across goroutines without external synchronization.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ func main() {
 - `KeySizeNDX`: 32 bytes (ipcrypt-ndx)
 - `TweakSize`: 8 bytes (ipcrypt-nd tweak)
 - `TweakSizeX`: 16 bytes (ipcrypt-ndx tweak)
-- `MaxIPLength`: 16 bytes
-- `NonDeterministicSize`: 24 bytes (`TweakSize + MaxIPLength`)
-- `NonDeterministicXSize`: 32 bytes (`TweakSizeX + MaxIPLength`)
+- `MaxIPSize`: 16 bytes
+- `NonDeterministicSize`: 24 bytes (`TweakSize + MaxIPSize`)
+- `NonDeterministicXSize`: 32 bytes (`TweakSizeX + MaxIPSize`)
 
 ### Types
 
-- `ScratchPad` - reusable scratch buffers to reduce allocations even further using the `ToScratch` APIs across repeated calls
+- `ScratchPad` - reusable scratch buffers and cached internal state for the zero-allocation `To` APIs across repeated calls
 - `NewScratchPad() *ScratchPad` - creates and initializes a scratch pad
 
 ### Functions
@@ -104,46 +104,90 @@ func main() {
 #### Deterministic Mode
 - `EncryptIP(key []byte, ip net.IP) (net.IP, error)` - Encrypts an IP address deterministically
 - `DecryptIP(key []byte, encrypted net.IP) (net.IP, error)` - Decrypts an IP address deterministically
-- `EncryptIPTo(key []byte, ip net.IP, encrypted []byte) (net.IP, error)` - Encrypts an IP address deterministically into a preallocated buffer of at least `MaxIPLength` bytes
-- `DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte) (net.IP, error)` - Decrypts an IP address deterministically into a preallocated buffer of at least `MaxIPLength` bytes
+- `EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation deterministic encryption into a preallocated buffer of at least `MaxIPSize` bytes
+- `DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation deterministic decryption into a preallocated buffer of at least `MaxIPSize` bytes
 
 #### Prefix-Preserving Mode (ipcrypt-pfx)
 - `EncryptIPPfx(ip net.IP, key []byte) (net.IP, error)` - Encrypts an IP address with prefix preservation
 - `DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error)` - Decrypts an IP address with prefix preservation
-- `EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte) (net.IP, error)` - Encrypts an IP address with prefix preservation into a preallocated buffer of at least `MaxIPLength` bytes
-- `DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte) (net.IP, error)` - Decrypts an IP address with prefix preservation into a preallocated buffer of at least `MaxIPLength` bytes
-- `EncryptIPPfxToScratch(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Same as `EncryptIPPfxTo`, but reuses scratch buffers across calls
-- `DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Same as `DecryptIPPfxTo`, but reuses scratch buffers across calls
+- `EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation prefix-preserving encryption into a preallocated buffer of at least `MaxIPSize` bytes
+- `DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation prefix-preserving decryption into a preallocated buffer of at least `MaxIPSize` bytes
 
 #### Non-Deterministic Mode (ipcrypt-nd)
 - `EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, error)` - Encrypts with 8-byte tweak
 - `DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error)` - Decrypts ipcrypt-nd ciphertext
-- `EncryptIPNonDeterministicTo(ip string, key []byte, tweak []byte, encrypted []byte) ([]byte, error)` - Encrypts into a preallocated buffer of at least `NonDeterministicSize` bytes
-- `DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte) (net.IP, error)` - Decrypts into a preallocated buffer of at least `MaxIPLength` bytes
+- `EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error)` - Zero-allocation encryption into a preallocated buffer of at least `NonDeterministicSize` bytes
+- `DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation decryption into a preallocated buffer of at least `MaxIPSize` bytes
 
 #### Extended Non-Deterministic Mode (ipcrypt-ndx)
 - `EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, error)` - Encrypts with 16-byte tweak
 - `DecryptIPNonDeterministicX(ciphertext []byte, key []byte) (string, error)` - Decrypts ipcrypt-ndx ciphertext
-- `EncryptIPNonDeterministicXTo(ip string, key []byte, tweak []byte, encrypted []byte) ([]byte, error)` - Encrypts into a preallocated buffer of at least `NonDeterministicXSize` bytes
-- `DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte) (net.IP, error)` - Decrypts into a preallocated buffer of at least `MaxIPLength` bytes
-- `EncryptIPNonDeterministicXToScratch(ip string, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error)` - Same as `EncryptIPNonDeterministicXTo`, but reuses scratch buffers across calls
-- `DecryptIPNonDeterministicXToScratch(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Same as `DecryptIPNonDeterministicXTo`, but reuses scratch buffers across calls
+- `EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error)` - Zero-allocation encryption into a preallocated buffer of at least `NonDeterministicXSize` bytes
+- `DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation decryption into a preallocated buffer of at least `MaxIPSize` bytes
 
-## Buffer Reuse
+## Zero-Allocation Usage
 
-The `To` functions write into caller-provided buffers in order to avoid allocating result slices on every call.
-
-For repeated calls in `ipcrypt-pfx` and `ipcrypt-ndx`, the `ToScratch` variants can further reduce allocations by reusing internal temporary buffers:
+The `To` functions write into caller-provided buffers and take a reusable `ScratchPad`. Reusing both across calls gives you zero-allocation behaviour.
 
 ```go
 scratch := ipcrypt.NewScratchPad()
-buf := make([]byte, ipcrypt.MaxIPLength)
+buf := make([]byte, ipcrypt.MaxIPSize)
 
 for ip := range ips {
-    encrypted, err := ipcrypt.EncryptIPPfxToScratch(ip, key, buf, scratch)
+    encrypted, err := ipcrypt.EncryptIPPfxTo(ip, key, buf, scratch)
     if err != nil {
         panic(err)
     }
 	// use buf in some way
 }
+```
+
+Note that the scratch pad must be initialized before use. _Also, you cannot reuse the same scratch pad across different keys._
+
+## Performance
+
+Depending on the mode, using the `To` functions can be almost an order of magnitude faster (deterministic and ndx modes) 
+if you are performing multiple conversions using the same scratch pad. The `To` functions save around 100+ns per conversion
+on a M4 Mac, so the difference is less noticeable for the `nd` and `pfx` modes, which are slower (particularly 
+encrypting/decrypting IPV6 addresses in `pfx` mode and descrypting addresses in `nd` mode).
+
+Running `go test -bench BenchmarkAllocations -benchmem` will give you benchmark results for each of the modes and API
+calls, for example:
+```
+goos: darwin
+goarch: arm64
+pkg: github.com/jedisct1/go-ipcrypt
+cpu: Apple M4
+BenchmarkAllocations/DeterministicEncrypt/IPv4-10    	 9683328	       104.4 ns/op	     528 B/op	       2 allocs/op
+BenchmarkAllocations/DeterministicEncrypt/IPv6-10    	11758062	       101.9 ns/op	     528 B/op	       2 allocs/op
+BenchmarkAllocations/DeterministicEncryptTo/IPv4-10  	96331054	        12.76 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/DeterministicEncryptTo/IPv6-10  	96211665	        12.74 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/DeterministicDecrypt/IPv4-10    	11532612	       102.8 ns/op	     528 B/op	       2 allocs/op
+BenchmarkAllocations/DeterministicDecrypt/IPv6-10    	11747846	       103.4 ns/op	     528 B/op	       2 allocs/op
+BenchmarkAllocations/DeterministicDecryptTo/IPv4-10  	96473685	        12.78 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/DeterministicDecryptTo/IPv6-10  	94559234	        12.98 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/NDEncrypt/IPv4-10               	 4494896	       264.9 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAllocations/NDEncrypt/IPv6-10               	 4378069	       271.8 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAllocations/NDEncryptTo/IPv4-10             	 6718228	       179.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/NDEncryptTo/IPv6-10             	 6710262	       179.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/NDDecrypt/IPv4-10               	  530713	      2268 ns/op	       8 B/op	       1 allocs/op
+BenchmarkAllocations/NDDecrypt/IPv6-10               	  533724	      2294 ns/op	      16 B/op	       1 allocs/op
+BenchmarkAllocations/NDDecryptTo/IPv4-10             	  562756	      2183 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/NDDecryptTo/IPv6-10             	  547240	      2178 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/NDXEncrypt/IPv4-10              	 4906118	       244.0 ns/op	    1568 B/op	       4 allocs/op
+BenchmarkAllocations/NDXEncrypt/IPv6-10              	 4745586	       253.5 ns/op	    1568 B/op	       4 allocs/op
+BenchmarkAllocations/NDXEncryptTo/IPv4-10            	36069930	        33.57 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/NDXEncryptTo/IPv6-10            	36468759	        33.34 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/NDXDecrypt/IPv4-10              	 4810798	       248.5 ns/op	    1560 B/op	       5 allocs/op
+BenchmarkAllocations/NDXDecrypt/IPv6-10              	 4426274	       266.8 ns/op	    1568 B/op	       5 allocs/op
+BenchmarkAllocations/NDXDecryptTo/IPv4-10            	40063990	        29.97 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/NDXDecryptTo/IPv6-10            	40379679	        30.03 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/PFXEncrypt/IPv4-10              	 1335013	       897.1 ns/op	    1552 B/op	       4 allocs/op
+BenchmarkAllocations/PFXEncrypt/IPv6-10              	  386245	      3112 ns/op	    1552 B/op	       4 allocs/op
+BenchmarkAllocations/PFXEncryptTo/IPv4-10            	 1614217	       744.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/PFXEncryptTo/IPv6-10            	  403288	      3010 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/PFXDecrypt/IPv4-10              	 1626735	       735.7 ns/op	    1552 B/op	       4 allocs/op
+BenchmarkAllocations/PFXDecrypt/IPv6-10              	  499734	      2430 ns/op	    1552 B/op	       4 allocs/op
+BenchmarkAllocations/PFXDecryptTo/IPv4-10            	 2117570	       569.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAllocations/PFXDecryptTo/IPv6-10            	  507560	      2363 ns/op	       0 B/op	       0 allocs/op
 ```

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ func main() {
 - `KeySizeDeterministic`: 16 bytes (ipcrypt-deterministic)
 - `KeySizeND`: 16 bytes (ipcrypt-nd)
 - `KeySizeNDX`: 32 bytes (ipcrypt-ndx)
+- `KeySizePFX`: 32 bytes (ipcrypt-pfx, split into two AES-128 keys)
 - `TweakSize`: 8 bytes (ipcrypt-nd tweak)
 - `TweakSizeX`: 16 bytes (ipcrypt-ndx tweak)
 - `NonDeterministicSize`: 24 bytes (`TweakSize + net.IPv6len`)
@@ -107,6 +108,8 @@ func main() {
 - `DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation deterministic decryption into a preallocated buffer of exactly `net.IPv6len` bytes
 
 #### Prefix-Preserving Mode (ipcrypt-pfx)
+All `ipcrypt-pfx` functions require a key of exactly `KeySizePFX` bytes, split into two distinct AES-128 keys.
+
 - `EncryptIPPfx(ip net.IP, key []byte) (net.IP, error)` - Encrypts an IP address with prefix preservation
 - `DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error)` - Decrypts an IP address with prefix preservation
 - `EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Zero-allocation prefix-preserving encryption into a preallocated buffer of exactly `net.IPv4len` bytes for IPv4 or exactly `net.IPv6len` bytes for IPv6

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ func main() {
         panic(err)
     }
     fmt.Printf("Extended non-deterministic decrypted: %s\n", decryptedX)
+
+    // ipcrypt-pfx mode
+    pfxKey := make([]byte, ipcrypt.KeySizePFX)
+    rand.Read(pfxKey)
+
+    encryptedPFX, err := ipcrypt.EncryptIPPfx(ip, pfxKey)
+    if err != nil {
+        panic(err)
+    }
+
+    decryptedPFX, err := ipcrypt.DecryptIPPfx(encryptedPFX, pfxKey)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("Prefix-preserving decrypted: %s\n", decryptedPFX)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,21 +90,60 @@ func main() {
 - `KeySizeNDX`: 32 bytes (ipcrypt-ndx)
 - `TweakSize`: 8 bytes (ipcrypt-nd tweak)
 - `TweakSizeX`: 16 bytes (ipcrypt-ndx tweak)
+- `MaxIPLength`: 16 bytes
+- `NonDeterministicSize`: 24 bytes (`TweakSize + MaxIPLength`)
+- `NonDeterministicXSize`: 32 bytes (`TweakSizeX + MaxIPLength`)
+
+### Types
+
+- `ScratchPad` - reusable scratch buffers to reduce allocations even further using the `ToScratch` APIs across repeated calls
+- `NewScratchPad() *ScratchPad` - creates and initializes a scratch pad
 
 ### Functions
 
 #### Deterministic Mode
 - `EncryptIP(key []byte, ip net.IP) (net.IP, error)` - Encrypts an IP address deterministically
 - `DecryptIP(key []byte, encrypted net.IP) (net.IP, error)` - Decrypts an IP address deterministically
+- `EncryptIPTo(key []byte, ip net.IP, encrypted []byte) (net.IP, error)` - Encrypts an IP address deterministically into a preallocated buffer of at least `MaxIPLength` bytes
+- `DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte) (net.IP, error)` - Decrypts an IP address deterministically into a preallocated buffer of at least `MaxIPLength` bytes
 
 #### Prefix-Preserving Mode (ipcrypt-pfx)
 - `EncryptIPPfx(ip net.IP, key []byte) (net.IP, error)` - Encrypts an IP address with prefix preservation
 - `DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error)` - Decrypts an IP address with prefix preservation
+- `EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte) (net.IP, error)` - Encrypts an IP address with prefix preservation into a preallocated buffer of at least `MaxIPLength` bytes
+- `DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte) (net.IP, error)` - Decrypts an IP address with prefix preservation into a preallocated buffer of at least `MaxIPLength` bytes
+- `EncryptIPPfxToScratch(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error)` - Same as `EncryptIPPfxTo`, but reuses scratch buffers across calls
+- `DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Same as `DecryptIPPfxTo`, but reuses scratch buffers across calls
 
 #### Non-Deterministic Mode (ipcrypt-nd)
 - `EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, error)` - Encrypts with 8-byte tweak
 - `DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error)` - Decrypts ipcrypt-nd ciphertext
+- `EncryptIPNonDeterministicTo(ip string, key []byte, tweak []byte, encrypted []byte) ([]byte, error)` - Encrypts into a preallocated buffer of at least `NonDeterministicSize` bytes
+- `DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte) (net.IP, error)` - Decrypts into a preallocated buffer of at least `MaxIPLength` bytes
 
 #### Extended Non-Deterministic Mode (ipcrypt-ndx)
 - `EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, error)` - Encrypts with 16-byte tweak
 - `DecryptIPNonDeterministicX(ciphertext []byte, key []byte) (string, error)` - Decrypts ipcrypt-ndx ciphertext
+- `EncryptIPNonDeterministicXTo(ip string, key []byte, tweak []byte, encrypted []byte) ([]byte, error)` - Encrypts into a preallocated buffer of at least `NonDeterministicXSize` bytes
+- `DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte) (net.IP, error)` - Decrypts into a preallocated buffer of at least `MaxIPLength` bytes
+- `EncryptIPNonDeterministicXToScratch(ip string, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error)` - Same as `EncryptIPNonDeterministicXTo`, but reuses scratch buffers across calls
+- `DecryptIPNonDeterministicXToScratch(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error)` - Same as `DecryptIPNonDeterministicXTo`, but reuses scratch buffers across calls
+
+## Buffer Reuse
+
+The `To` functions write into caller-provided buffers in order to avoid allocating result slices on every call.
+
+For repeated calls in `ipcrypt-pfx` and `ipcrypt-ndx`, the `ToScratch` variants can further reduce allocations by reusing internal temporary buffers:
+
+```go
+scratch := ipcrypt.NewScratchPad()
+buf := make([]byte, ipcrypt.MaxIPLength)
+
+for ip := range ips {
+    encrypted, err := ipcrypt.EncryptIPPfxToScratch(ip, key, buf, scratch)
+    if err != nil {
+        panic(err)
+    }
+	// use buf in some way
+}
+```

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -30,12 +30,62 @@ const (
 	TweakSizeX = 16 // Size in bytes of the tweak for ipcrypt-ndx mode
 )
 
+// Max length of an encrypted or decrypted IP address
+const (
+	MaxIPLength           = 16 // Maximum length of an encrypted IP address in bytes
+	NonDeterministicSize  = TweakSize + MaxIPLength
+	NonDeterministicXSize = TweakSizeX + MaxIPLength
+)
+
+var (
+	pfxIPv4PaddedPrefix = [MaxIPLength]byte{3: 0x01, 14: 0xFF, 15: 0xFF}
+	pfxIPv6PaddedPrefix = [MaxIPLength]byte{15: 0x01}
+)
+
 // Error definitions for the package
 var (
 	ErrInvalidKeySize = errors.New("invalid key size")
 	ErrInvalidIP      = errors.New("invalid IP address")
 	ErrInvalidTweak   = errors.New("invalid tweak size")
 )
+
+// ScratchPad enables reuse of byte slices during encryption and decryption operations to avoid allocations
+type ScratchPad struct {
+	Scratch1 []byte
+	Scratch2 []byte
+	Scratch3 []byte
+	Scratch4 []byte
+}
+
+// init initializes the scratchpad with empty byte slices of the appropriate size if necessary
+func (s *ScratchPad) init() {
+	if s.Scratch1 == nil {
+		s.Scratch1 = make([]byte, MaxIPLength)
+	}
+	if s.Scratch2 == nil {
+		s.Scratch2 = make([]byte, MaxIPLength)
+	}
+	if s.Scratch3 == nil {
+		s.Scratch3 = make([]byte, MaxIPLength)
+	}
+	if s.Scratch4 == nil {
+		s.Scratch4 = make([]byte, MaxIPLength)
+	}
+}
+
+func getScratchPad(scratch *ScratchPad) *ScratchPad {
+	if scratch == nil {
+		return NewScratchPad()
+	}
+	scratch.init()
+	return scratch
+}
+
+func NewScratchPad() *ScratchPad {
+	s := ScratchPad{}
+	s.init()
+	return &s
+}
 
 // Utility functions
 
@@ -67,23 +117,41 @@ func validateTweak(tweak []byte, expectedSize int) error {
 	return nil
 }
 
-// xorBytes performs XOR operation on two byte slices of equal length
-func xorBytes(a, b []byte) []byte {
-	if len(a) != len(b) {
+// xorBytesTo performs XOR operation on two byte slices of equal length.
+// The to parameter must be a byte slice of equal length to a and b.
+func xorBytesTo(a, b, to []byte) []byte {
+	if len(a) != len(b) || len(to) != len(b) {
 		return nil
 	}
-	c := make([]byte, len(a))
-	subtle.XORBytes(c, a, b)
-	return c
+	subtle.XORBytes(to, a, b)
+	return to
+}
+
+// xorBytes performs XOR operation on two byte slices of equal length.
+func xorBytes(a, b []byte) []byte {
+	to := make([]byte, len(a))
+	return xorBytesTo(a, b, to)
+}
+
+func validateOutputLength(buf []byte, expectedSize int, parameterName string) error {
+	if len(buf) < expectedSize {
+		return fmt.Errorf("invalid %s parameter: got %d bytes, want at least %d bytes", parameterName, len(buf), expectedSize)
+	}
+	return nil
 }
 
 // Deterministic mode functions
 
 // EncryptIP encrypts an IP address using ipcrypt-deterministic mode.
 // The key must be exactly KeySizeDeterministic bytes long.
+// The encrypted parameter must be a byte slice of minimum MaxIPLength bytes long
 // Returns the encrypted IP address as a net.IP.
-func EncryptIP(key []byte, ip net.IP) (net.IP, error) {
+func EncryptIPTo(key []byte, ip net.IP, encrypted []byte) (net.IP, error) {
 	if err := validateKey(key, KeySizeDeterministic); err != nil {
+		return nil, err
+	}
+
+	if err := validateOutputLength(encrypted, MaxIPLength, "encrypted"); err != nil {
 		return nil, err
 	}
 
@@ -97,17 +165,29 @@ func EncryptIP(key []byte, ip net.IP) (net.IP, error) {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
 	}
 
-	encrypted := make([]byte, 16)
 	block.Encrypt(encrypted, ipBytes)
 
 	return net.IP(encrypted), nil
 }
 
+// EncryptIP encrypts an IP address using ipcrypt-deterministic mode.
+// The key must be exactly KeySizeDeterministic bytes long.
+// Returns the encrypted IP address as a net.IP.
+func EncryptIP(key []byte, ip net.IP) (net.IP, error) {
+	encrypted := make([]byte, 16)
+	return EncryptIPTo(key, ip, encrypted)
+}
+
 // DecryptIP decrypts an IP address that was encrypted using ipcrypt-deterministic mode.
 // The key must be exactly KeySizeDeterministic bytes long.
+// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long
 // Returns the decrypted IP address as a net.IP.
-func DecryptIP(key []byte, encrypted net.IP) (net.IP, error) {
+func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte) (net.IP, error) {
 	if err := validateKey(key, KeySizeDeterministic); err != nil {
+		return nil, err
+	}
+
+	if err := validateOutputLength(decrypted, MaxIPLength, "decrypted"); err != nil {
 		return nil, err
 	}
 
@@ -121,10 +201,17 @@ func DecryptIP(key []byte, encrypted net.IP) (net.IP, error) {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
 	}
 
-	decrypted := make([]byte, 16)
 	block.Decrypt(decrypted, ipBytes)
 
 	return net.IP(decrypted), nil
+}
+
+// DecryptIP decrypts an IP address that was encrypted using ipcrypt-deterministic mode.
+// The key must be exactly KeySizeDeterministic bytes long.
+// Returns the decrypted IP address as a net.IP.
+func DecryptIP(key []byte, encrypted net.IP) (net.IP, error) {
+	decrypted := make([]byte, 16)
+	return DecryptIPTo(key, encrypted, decrypted)
 }
 
 // Non-deterministic mode functions
@@ -132,9 +219,14 @@ func DecryptIP(key []byte, encrypted net.IP) (net.IP, error) {
 // EncryptIPNonDeterministic encrypts an IP address using ipcrypt-nd mode.
 // The key must be exactly KeySizeND bytes long.
 // If tweak is nil, a random tweak will be generated.
+// The encrypted parameter must be a byte slice of minimum NonDeterministicSize bytes long.
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
-func EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, error) {
+func EncryptIPNonDeterministicTo(ip string, key []byte, tweak []byte, encrypted []byte) ([]byte, error) {
 	if err := validateKey(key, KeySizeND); err != nil {
+		return nil, err
+	}
+
+	if err := validateOutputLength(encrypted, NonDeterministicSize, "encrypted"); err != nil {
 		return nil, err
 	}
 
@@ -145,7 +237,7 @@ func EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, err
 
 	var t []byte
 	if tweak == nil {
-		t = make([]byte, TweakSize)
+		t = encrypted[:TweakSize]
 		if _, err := rand.Read(t); err != nil {
 			return nil, fmt.Errorf("failed to generate tweak: %w", err)
 		}
@@ -154,48 +246,84 @@ func EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, err
 			return nil, err
 		}
 		t = tweak
+		copy(encrypted[:TweakSize], t)
 	}
 
-	encrypted, err := KiasuBCEncrypt(key, t, ipBytes)
+	ciphertext, err := KiasuBCEncrypt(key, t, ipBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]byte, TweakSize+16)
-	copy(result[:TweakSize], t)
-	copy(result[TweakSize:], encrypted)
-	return result, nil
+	copy(encrypted[TweakSize:], ciphertext)
+	return encrypted[:NonDeterministicSize], nil
+}
+
+// EncryptIPNonDeterministic encrypts an IP address using ipcrypt-nd mode.
+// The key must be exactly KeySizeND bytes long.
+// If tweak is nil, a random tweak will be generated.
+// Returns a byte slice containing the tweak concatenated with the encrypted IP.
+func EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, error) {
+	encrypted := make([]byte, NonDeterministicSize)
+	return EncryptIPNonDeterministicTo(ip, key, tweak, encrypted)
+}
+
+// DecryptIPNonDeterministicTo decrypts an IP address that was encrypted using ipcrypt-nd mode.
+// The key must be exactly KeySizeND bytes long.
+// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// Returns the decrypted IP address as a net.IP.
+func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte) (net.IP, error) {
+	if err := validateKey(key, KeySizeND); err != nil {
+		return nil, err
+	}
+
+	if len(ciphertext) != NonDeterministicSize {
+		return nil, fmt.Errorf("invalid ciphertext length: got %d, want %d", len(ciphertext), NonDeterministicSize)
+	}
+
+	if err := validateOutputLength(decrypted, MaxIPLength, "decrypted"); err != nil {
+		return nil, err
+	}
+
+	tweak := ciphertext[:TweakSize]
+	encryptedIP := ciphertext[TweakSize:]
+
+	plainIP, err := KiasuBCDecrypt(key, tweak, encryptedIP)
+	if err != nil {
+		return nil, err
+	}
+
+	copy(decrypted, plainIP)
+	return net.IP(decrypted[:MaxIPLength]), nil
 }
 
 // DecryptIPNonDeterministic decrypts an IP address that was encrypted using ipcrypt-nd mode.
 // The key must be exactly KeySizeND bytes long.
 // Returns the decrypted IP address as a string.
 func DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error) {
-	if err := validateKey(key, KeySizeND); err != nil {
-		return "", err
-	}
-
-	if len(ciphertext) != TweakSize+16 {
-		return "", fmt.Errorf("invalid ciphertext length: got %d, want %d", len(ciphertext), TweakSize+16)
-	}
-
-	tweak := ciphertext[:TweakSize]
-	encryptedIP := ciphertext[TweakSize:]
-
-	decrypted, err := KiasuBCDecrypt(key, tweak, encryptedIP)
+	decrypted := make([]byte, MaxIPLength)
+	ip, err := DecryptIPNonDeterministicTo(ciphertext, key, decrypted)
 	if err != nil {
 		return "", err
 	}
 
-	return net.IP(decrypted).String(), nil
+	return ip.String(), nil
 }
 
 // Prefix-preserving mode functions
 
-// EncryptIPPfx encrypts an IP address using ipcrypt-pfx mode.
+// EncryptIPPfxTo encrypts an IP address using ipcrypt-pfx mode.
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
-// Returns the encrypted IP address maintaining the original format (IPv4 or IPv6).
-func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
+// The encrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// Returns the encrypted IP address in 16-byte form.
+func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte) (net.IP, error) {
+	return EncryptIPPfxToScratch(ip, key, encrypted, nil)
+}
+
+// EncryptIPPfxToScratch encrypts an IP address using ipcrypt-pfx mode using the provided scratchpad to avoid allocations.
+// The key must be exactly 32 bytes long (split into two AES-128 keys).
+// The encrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// Returns the encrypted IP address in 16-byte form.
+func EncryptIPPfxToScratch(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if len(key) != 32 {
 		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
 	}
@@ -228,9 +356,12 @@ func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
 
 	// Determine if this is IPv4
 	isIPv4 := ip.To4() != nil
+	if err := validateOutputLength(encrypted, MaxIPLength, "encrypted"); err != nil {
+		return nil, err
+	}
+	scratch = getScratchPad(scratch)
 
-	// Initialize encrypted result
-	encrypted := make([]byte, 16)
+	encrypted = encrypted[:MaxIPLength]
 
 	// Determine starting point
 	prefixStart := 0
@@ -241,28 +372,24 @@ func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
 	}
 
 	// Initialize padded prefix for the starting prefix length
-	paddedPrefix := make([]byte, 16)
+	paddedPrefix := scratch.Scratch1[:MaxIPLength]
 	if isIPv4 {
-		// For IPv4: pad_prefix_96
-		paddedPrefix[3] = 0x01 // Set bit at position 96
-		paddedPrefix[14] = 0xFF
-		paddedPrefix[15] = 0xFF
+		copy(paddedPrefix, pfxIPv4PaddedPrefix[:])
 	} else {
-		// For IPv6: pad_prefix_0
-		paddedPrefix[15] = 0x01 // Set bit at position 0
+		copy(paddedPrefix, pfxIPv6PaddedPrefix[:])
 	}
 
 	// Process each bit position
 	for prefixLenBits := prefixStart; prefixLenBits < 128; prefixLenBits++ {
 		// Compute pseudorandom function with dual AES encryption
-		e1 := make([]byte, 16)
+		e1 := scratch.Scratch2[:MaxIPLength]
 		cipher1.Encrypt(e1, paddedPrefix)
 
-		e2 := make([]byte, 16)
+		e2 := scratch.Scratch3[:MaxIPLength]
 		cipher2.Encrypt(e2, paddedPrefix)
 
 		// XOR the two encryptions
-		e := xorBytes(e1, e2)
+		e := xorBytesTo(e1, e2, scratch.Scratch4[:MaxIPLength])
 		// We only need the least significant bit
 		cipherBit := e[15] & 1
 
@@ -275,22 +402,34 @@ func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
 
 		// Prepare padded_prefix for next iteration
 		// Shift left by 1 bit and insert the next bit from ipBytes
-		paddedPrefix = shiftLeftOneBit(paddedPrefix)
+		shiftLeftOneBit(paddedPrefix)
 		setBit(paddedPrefix, 0, originalBit)
 	}
 
-	// Return the appropriate format
-	if isIPv4 {
-		// Return just the IPv4 part
-		return net.IP(encrypted[12:16]), nil
-	}
 	return net.IP(encrypted), nil
 }
 
-// DecryptIPPfx decrypts an IP address that was encrypted using ipcrypt-pfx mode.
+// EncryptIPPfx encrypts an IP address using ipcrypt-pfx mode.
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
-// Returns the decrypted IP address.
-func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
+// Returns the encrypted IP address maintaining the original format (IPv4 or IPv6).
+func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
+	encrypted := make([]byte, MaxIPLength)
+	return EncryptIPPfxTo(ip, key, encrypted)
+}
+
+// DecryptIPPfxTo decrypts an IP address that was encrypted using ipcrypt-pfx mode.
+// The key must be exactly 32 bytes long (split into two AES-128 keys).
+// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// Returns the decrypted IP address
+func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte) (net.IP, error) {
+	return DecryptIPPfxToScratch(encryptedIP, key, decrypted, nil)
+}
+
+// DecryptIPPfxToScratch decrypts an IP address that was encrypted using ipcrypt-pfx mode using the provided scratchpad to avoid allocations.
+// The key must be exactly 32 bytes long (split into two AES-128 keys).
+// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// Returns the decrypted IP address
+func DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if len(key) != 32 {
 		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
 	}
@@ -307,6 +446,10 @@ func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
 	// Keep IPv4 ciphertexts in their IPv4 code path, but normalize them to
 	// the 16-byte IPv4-mapped form before the bitwise decryption loop.
 	isIPv4 := encryptedIP.To4() != nil
+	if err := validateOutputLength(decrypted, MaxIPLength, "decrypted"); err != nil {
+		return nil, err
+	}
+	scratch = getScratchPad(scratch)
 
 	encryptedBytes, err := validateIP(encryptedIP)
 	if err != nil {
@@ -324,8 +467,7 @@ func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
 		return nil, fmt.Errorf("failed to create second cipher: %w", err)
 	}
 
-	// Initialize decrypted result
-	decrypted := make([]byte, 16)
+	decrypted = decrypted[:MaxIPLength]
 
 	// Determine starting point
 	prefixStart := 0
@@ -336,28 +478,24 @@ func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
 	}
 
 	// Initialize padded prefix for the starting prefix length
-	paddedPrefix := make([]byte, 16)
+	paddedPrefix := scratch.Scratch1[:MaxIPLength]
 	if isIPv4 {
-		// For IPv4: pad_prefix_96
-		paddedPrefix[3] = 0x01 // Set bit at position 96
-		paddedPrefix[14] = 0xFF
-		paddedPrefix[15] = 0xFF
+		copy(paddedPrefix, pfxIPv4PaddedPrefix[:])
 	} else {
-		// For IPv6: pad_prefix_0
-		paddedPrefix[15] = 0x01 // Set bit at position 0
+		copy(paddedPrefix, pfxIPv6PaddedPrefix[:])
 	}
 
 	// Process each bit position
 	for prefixLenBits := prefixStart; prefixLenBits < 128; prefixLenBits++ {
 		// Compute pseudorandom function with dual AES encryption
-		e1 := make([]byte, 16)
+		e1 := scratch.Scratch2[:MaxIPLength]
 		cipher1.Encrypt(e1, paddedPrefix)
 
-		e2 := make([]byte, 16)
+		e2 := scratch.Scratch3[:MaxIPLength]
 		cipher2.Encrypt(e2, paddedPrefix)
 
 		// XOR the two encryptions
-		e := xorBytes(e1, e2)
+		e := xorBytesTo(e1, e2, scratch.Scratch4[:MaxIPLength])
 		// We only need the least significant bit
 		cipherBit := e[15] & 1
 
@@ -371,16 +509,19 @@ func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
 
 		// Prepare padded_prefix for next iteration
 		// Shift left by 1 bit and insert the next bit from decrypted
-		paddedPrefix = shiftLeftOneBit(paddedPrefix)
+		shiftLeftOneBit(paddedPrefix)
 		setBit(paddedPrefix, 0, originalBit)
 	}
 
-	// Return the appropriate format
-	if isIPv4 {
-		// Return just the IPv4 part
-		return net.IP(decrypted[12:16]), nil
-	}
 	return net.IP(decrypted), nil
+}
+
+// DecryptIPPfx decrypts an IP address that was encrypted using ipcrypt-pfx mode.
+// The key must be exactly 32 bytes long (split into two AES-128 keys).
+// Returns the decrypted IP address.
+func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
+	decrypted := make([]byte, MaxIPLength)
+	return DecryptIPPfxTo(encryptedIP, key, decrypted)
 }
 
 // Helper functions for bit manipulation
@@ -405,37 +546,50 @@ func setBit(data []byte, position int, value byte) {
 	}
 }
 
-// shiftLeftOneBit shifts a 16-byte array one bit to the left
-// The most significant bit is lost, and a zero bit is shifted in from the right
-func shiftLeftOneBit(data []byte) []byte {
+// shiftLeftOneBit shifts a 16-byte array one bit to the left in place.
+// The most significant bit is lost, and a zero bit is shifted in from the right.
+func shiftLeftOneBit(data []byte) {
 	if len(data) != 16 {
-		return nil
+		return
 	}
 
-	result := make([]byte, 16)
 	carry := byte(0)
 
 	// Process from least significant byte (byte 15) to most significant (byte 0)
 	for i := 15; i >= 0; i-- {
+		nextCarry := (data[i] >> 7) & 1
 		// Current byte shifted left by 1, with carry from previous byte
-		result[i] = (data[i] << 1) | carry
+		data[i] = (data[i] << 1) | carry
 		// Extract the bit that will be carried to the next byte
-		carry = (data[i] >> 7) & 1
+		carry = nextCarry
 	}
-
-	return result
 }
 
 // Extended non-deterministic mode functions
 
-// EncryptIPNonDeterministicX encrypts an IP address using ipcrypt-ndx mode.
+// EncryptIPNonDeterministicXTo encrypts an IP address using ipcrypt-ndx mode.
 // The key must be exactly KeySizeNDX bytes long.
 // If tweak is nil, a random tweak will be generated.
+// The encrypted parameter must be a byte slice of minimum NonDeterministicXSize bytes long.
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
-func EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, error) {
+func EncryptIPNonDeterministicXTo(ip string, key []byte, tweak []byte, encrypted []byte) ([]byte, error) {
+	return EncryptIPNonDeterministicXToScratch(ip, key, tweak, encrypted, nil)
+}
+
+// EncryptIPNonDeterministicXToScratch encrypts an IP address using ipcrypt-ndx mode using the provided scratchpad to avoid allocations.
+// The key must be exactly KeySizeNDX bytes long.
+// If tweak is nil, a random tweak will be generated.
+// The encrypted parameter must be a byte slice of minimum NonDeterministicXSize bytes long.
+// Returns a byte slice containing the tweak concatenated with the encrypted IP.
+func EncryptIPNonDeterministicXToScratch(ip string, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error) {
 	if err := validateKey(key, KeySizeNDX); err != nil {
 		return nil, err
 	}
+
+	if err := validateOutputLength(encrypted, NonDeterministicXSize, "encrypted"); err != nil {
+		return nil, err
+	}
+	scratch = getScratchPad(scratch)
 
 	ipBytes, err := validateIP(net.ParseIP(ip))
 	if err != nil {
@@ -457,7 +611,7 @@ func EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, er
 
 	var t []byte
 	if tweak == nil {
-		t = make([]byte, TweakSizeX)
+		t = encrypted[:TweakSizeX]
 		if _, err := rand.Read(t); err != nil {
 			return nil, fmt.Errorf("failed to generate tweak: %w", err)
 		}
@@ -466,73 +620,107 @@ func EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, er
 			return nil, err
 		}
 		t = tweak
+		copy(encrypted[:TweakSizeX], t)
 	}
 
-	encryptedTweak := make([]byte, 16)
+	encryptedTweak := scratch.Scratch1[:MaxIPLength]
 	block2.Encrypt(encryptedTweak, t)
 
-	xoredIP := xorBytes(ipBytes, encryptedTweak)
+	xoredIP := xorBytesTo(ipBytes, encryptedTweak, scratch.Scratch2[:MaxIPLength])
 	if xoredIP == nil {
 		return nil, errors.New("XOR operation failed")
 	}
 
-	encrypted := make([]byte, 16)
-	block1.Encrypt(encrypted, xoredIP)
+	block1.Encrypt(encrypted[TweakSizeX:], xoredIP)
 
-	finalEncrypted := xorBytes(encrypted, encryptedTweak)
+	finalEncrypted := xorBytesTo(encrypted[TweakSizeX:], encryptedTweak, scratch.Scratch3[:MaxIPLength])
 	if finalEncrypted == nil {
 		return nil, errors.New("XOR operation failed")
 	}
 
-	result := make([]byte, TweakSizeX+16)
-	copy(result[:TweakSizeX], t)
-	copy(result[TweakSizeX:], finalEncrypted)
-	return result, nil
+	copy(encrypted[TweakSizeX:], finalEncrypted)
+	return encrypted[:NonDeterministicXSize], nil
 }
 
-// DecryptIPNonDeterministicX decrypts an IP address that was encrypted using ipcrypt-ndx mode.
+// EncryptIPNonDeterministicX encrypts an IP address using ipcrypt-ndx mode.
 // The key must be exactly KeySizeNDX bytes long.
-// Returns the decrypted IP address as a string.
-func DecryptIPNonDeterministicX(ciphertext []byte, key []byte) (string, error) {
+// If tweak is nil, a random tweak will be generated.
+// Returns a byte slice containing the tweak concatenated with the encrypted IP.
+func EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, error) {
+	encrypted := make([]byte, NonDeterministicXSize)
+	return EncryptIPNonDeterministicXTo(ip, key, tweak, encrypted)
+}
+
+// DecryptIPNonDeterministicXTo decrypts an IP address that was encrypted using ipcrypt-ndx mode.
+// The key must be exactly KeySizeNDX bytes long.
+// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// Returns the decrypted IP address as a net.IP.
+func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte) (net.IP, error) {
+	return DecryptIPNonDeterministicXToScratch(ciphertext, key, decrypted, nil)
+}
+
+// DecryptIPNonDeterministicXToScratch decrypts an IP address that was encrypted using ipcrypt-ndx mode using the provided scratchpad to avoid allocations.
+// The key must be exactly KeySizeNDX bytes long.
+// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// Returns the decrypted IP address as a net.IP.
+func DecryptIPNonDeterministicXToScratch(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if err := validateKey(key, KeySizeNDX); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	if len(ciphertext) != TweakSizeX+16 {
-		return "", fmt.Errorf("invalid ciphertext length: got %d, want %d", len(ciphertext), TweakSizeX+16)
+	if len(ciphertext) != NonDeterministicXSize {
+		return nil, fmt.Errorf("invalid ciphertext length: got %d, want %d", len(ciphertext), NonDeterministicXSize)
 	}
+
+	if err := validateOutputLength(decrypted, MaxIPLength, "decrypted"); err != nil {
+		return nil, err
+	}
+	scratch = getScratchPad(scratch)
 
 	key1 := key[:KeySizeND]
 	key2 := key[KeySizeND:]
 
 	block1, err := aes.NewCipher(key1)
 	if err != nil {
-		return "", fmt.Errorf("failed to create first cipher: %w", err)
+		return nil, fmt.Errorf("failed to create first cipher: %w", err)
 	}
 
 	block2, err := aes.NewCipher(key2)
 	if err != nil {
-		return "", fmt.Errorf("failed to create second cipher: %w", err)
+		return nil, fmt.Errorf("failed to create second cipher: %w", err)
 	}
 
 	tweak := ciphertext[:TweakSizeX]
 	encryptedIP := ciphertext[TweakSizeX:]
 
-	encryptedTweak := make([]byte, 16)
+	encryptedTweak := scratch.Scratch1[:MaxIPLength]
 	block2.Encrypt(encryptedTweak, tweak)
 
-	xoredIP := xorBytes(encryptedIP, encryptedTweak)
+	xoredIP := xorBytesTo(encryptedIP, encryptedTweak, scratch.Scratch2[:MaxIPLength])
 	if xoredIP == nil {
-		return "", errors.New("XOR operation failed")
+		return nil, errors.New("XOR operation failed")
 	}
 
-	decrypted := make([]byte, 16)
 	block1.Decrypt(decrypted, xoredIP)
 
-	finalDecrypted := xorBytes(decrypted, encryptedTweak)
+	finalDecrypted := xorBytesTo(decrypted, encryptedTweak, scratch.Scratch3[:MaxIPLength])
 	if finalDecrypted == nil {
-		return "", errors.New("XOR operation failed")
+		return nil, errors.New("XOR operation failed")
 	}
 
-	return net.IP(finalDecrypted).String(), nil
+	copy(decrypted, finalDecrypted)
+	return net.IP(decrypted[:MaxIPLength]), nil
+}
+
+// DecryptIPNonDeterministicX decrypts an IP address that was encrypted using ipcrypt-ndx mode.
+// The key must be exactly KeySizeNDX bytes long.
+// Returns the decrypted IP address as a string.
+func DecryptIPNonDeterministicX(ciphertext []byte, key []byte) (string, error) {
+	decrypted := make([]byte, MaxIPLength)
+	ip, err := DecryptIPNonDeterministicXTo(ciphertext, key, decrypted)
+	if err != nil {
+		return "", err
+	}
+
+	return ip.String(), nil
 }

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -221,10 +221,10 @@ func EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (
 
 	ipBytes := []byte(ip)
 	if len(ip) != net.IPv6len {
-		if err := validateIPTo(ip, scratch.scratch1[:MaxIPSize]); err != nil {
+		if err := validateIPTo(ip, encrypted[:MaxIPSize]); err != nil {
 			return nil, err
 		}
-		ipBytes = scratch.scratch1[:MaxIPSize]
+		ipBytes = encrypted[:MaxIPSize]
 	}
 
 	block, err := scratch.getAESBlock(1, key)
@@ -266,10 +266,10 @@ func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *Scratc
 
 	ipBytes := []byte(encrypted)
 	if len(encrypted) != net.IPv6len {
-		if err := validateIPTo(encrypted, scratch.scratch1[:MaxIPSize]); err != nil {
+		if err := validateIPTo(encrypted, decrypted[:MaxIPSize]); err != nil {
 			return nil, err
 		}
-		ipBytes = scratch.scratch1[:MaxIPSize]
+		ipBytes = decrypted[:MaxIPSize]
 	}
 
 	block, err := scratch.getAESBlock(1, key)
@@ -447,7 +447,7 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 	if err := validateOutputLength(encrypted, MaxIPSize, "encrypted"); err != nil {
 		return nil, err
 	}
-	
+
 	// Determine starting point
 	prefixStart := 0
 	if isIPv4 {

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -33,15 +33,14 @@ const (
 
 // Max length of an encrypted or decrypted IP address
 const (
-	MaxIPSize             = 16 // Maximum size of an encrypted IP address in bytes
-	MaxScratchSize        = 16 // Maximum scratch buffer size in bytes
-	NonDeterministicSize  = TweakSize + MaxIPSize
-	NonDeterministicXSize = TweakSizeX + MaxIPSize
+	MaxScratchSize        = net.IPv6len // Maximum scratch buffer size in bytes
+	NonDeterministicSize  = TweakSize + net.IPv6len
+	NonDeterministicXSize = TweakSizeX + net.IPv6len
 )
 
 var (
-	pfxIPv4PaddedPrefix = [MaxIPSize]byte{3: 0x01, 14: 0xFF, 15: 0xFF}
-	pfxIPv6PaddedPrefix = [MaxIPSize]byte{15: 0x01}
+	pfxIPv4PaddedPrefix = [net.IPv6len]byte{3: 0x01, 14: 0xFF, 15: 0xFF}
+	pfxIPv6PaddedPrefix = [net.IPv6len]byte{15: 0x01}
 	ipv4MappedPrefix    = [12]byte{10: 0xFF, 11: 0xFF}
 )
 
@@ -193,8 +192,8 @@ func xorBytes(a, b []byte) []byte {
 }
 
 func validateOutputLength(buf []byte, expectedSize int, parameterName string) error {
-	if len(buf) < expectedSize {
-		return fmt.Errorf("invalid %s parameter: got %d bytes, want at least %d bytes", parameterName, len(buf), expectedSize)
+	if len(buf) != expectedSize {
+		return fmt.Errorf("invalid %s parameter: got %d bytes, want %d bytes", parameterName, len(buf), expectedSize)
 	}
 	return nil
 }
@@ -203,7 +202,7 @@ func validateOutputLength(buf []byte, expectedSize int, parameterName string) er
 
 // EncryptIPTo EncryptIP encrypts an IP address using ipcrypt-deterministic mode.
 // The key must be exactly KeySizeDeterministic bytes long.
-// The encrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The encrypted parameter must be exactly net.IPv6len bytes long.
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the encrypted IP address as a net.IP.
 func EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (net.IP, error) {
@@ -215,16 +214,16 @@ func EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (
 		return nil, err
 	}
 
-	if err := validateOutputLength(encrypted, MaxIPSize, "encrypted"); err != nil {
+	if err := validateOutputLength(encrypted, net.IPv6len, "encrypted"); err != nil {
 		return nil, err
 	}
 
 	ipBytes := []byte(ip)
 	if len(ip) != net.IPv6len {
-		if err := validateIPTo(ip, encrypted[:MaxIPSize]); err != nil {
+		if err := validateIPTo(ip, encrypted[:net.IPv6len]); err != nil {
 			return nil, err
 		}
-		ipBytes = encrypted[:MaxIPSize]
+		ipBytes = encrypted[:net.IPv6len]
 	}
 
 	block, err := scratch.getAESBlock(1, key)
@@ -248,7 +247,7 @@ func EncryptIP(key []byte, ip net.IP) (net.IP, error) {
 
 // DecryptIPTo DecryptIP decrypts an IP address that was encrypted using ipcrypt-deterministic mode.
 // The key must be exactly KeySizeDeterministic bytes long.
-// The decrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The decrypted parameter must be exactly net.IPv6len bytes long.
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
 func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
@@ -260,16 +259,16 @@ func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *Scratc
 		return nil, err
 	}
 
-	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
+	if err := validateOutputLength(decrypted, net.IPv6len, "decrypted"); err != nil {
 		return nil, err
 	}
 
 	ipBytes := []byte(encrypted)
 	if len(encrypted) != net.IPv6len {
-		if err := validateIPTo(encrypted, decrypted[:MaxIPSize]); err != nil {
+		if err := validateIPTo(encrypted, decrypted[:net.IPv6len]); err != nil {
 			return nil, err
 		}
-		ipBytes = decrypted[:MaxIPSize]
+		ipBytes = decrypted[:net.IPv6len]
 	}
 
 	block, err := scratch.getAESBlock(1, key)
@@ -296,7 +295,7 @@ func DecryptIP(key []byte, encrypted net.IP) (net.IP, error) {
 // EncryptIPNonDeterministicTo EncryptIPNonDeterministic encrypts an IP address using ipcrypt-nd mode.
 // The key must be exactly KeySizeND bytes long.
 // If tweak is nil, a random tweak will be generated.
-// The encrypted parameter must be a byte slice of minimum NonDeterministicSize bytes long.
+// The encrypted parameter must be exactly NonDeterministicSize bytes long.
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
 func EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error) {
@@ -314,10 +313,10 @@ func EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted 
 
 	ipBytes := []byte(ip)
 	if len(ip) != net.IPv6len {
-		if err := validateIPTo(ip, scratch.scratch1[:MaxIPSize]); err != nil {
+		if err := validateIPTo(ip, scratch.scratch1[:net.IPv6len]); err != nil {
 			return nil, err
 		}
-		ipBytes = scratch.scratch1[:MaxIPSize]
+		ipBytes = scratch.scratch1[:net.IPv6len]
 	}
 
 	var t []byte
@@ -353,7 +352,7 @@ func EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, err
 
 // DecryptIPNonDeterministicTo decrypts an IP address that was encrypted using ipcrypt-nd mode.
 // The key must be exactly KeySizeND bytes long.
-// The decrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The decrypted parameter must be exactly net.IPv6len bytes long.
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
 func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
@@ -369,7 +368,7 @@ func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte
 		return nil, fmt.Errorf("invalid ciphertext length: got %d, want %d", len(ciphertext), NonDeterministicSize)
 	}
 
-	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
+	if err := validateOutputLength(decrypted, net.IPv6len, "decrypted"); err != nil {
 		return nil, err
 	}
 
@@ -380,14 +379,14 @@ func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte
 	if err := kiasuBCDecryptTo(roundKeys, tweak, encryptedIP, decrypted, scratch.scratch1[:]); err != nil {
 		return nil, err
 	}
-	return net.IP(decrypted[:MaxIPSize]), nil
+	return net.IP(decrypted[:net.IPv6len]), nil
 }
 
 // DecryptIPNonDeterministic decrypts an IP address that was encrypted using ipcrypt-nd mode.
 // The key must be exactly KeySizeND bytes long.
 // Returns the decrypted IP address as a string.
 func DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error) {
-	decrypted := make([]byte, MaxIPSize)
+	decrypted := make([]byte, net.IPv6len)
 	scratch := ScratchPad{}
 	ip, err := DecryptIPNonDeterministicTo(ciphertext, key, decrypted, &scratch)
 	if err != nil {
@@ -401,9 +400,11 @@ func DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error) {
 
 // EncryptIPPfxTo encrypts an IP address using ipcrypt-pfx mode.
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
-// The encrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The encrypted parameter must be exactly net.IPv4len bytes for IPv4 inputs or exactly
+// net.IPv6len bytes for IPv6 inputs.
 // The scratch parameter provides reusable state to avoid allocations across calls.
-// Returns the encrypted IP address in 16-byte form.
+// Returns the encrypted IP address in net.IPv4len-byte form for IPv4 callers using a net.IPv4len-byte
+// destination buffer, or 16-byte form otherwise.
 func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if scratch == nil {
 		return nil, errors.New("scratch parameter must not be nil")
@@ -422,7 +423,7 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 		return nil, errors.New("the two halves of the key must be different")
 	}
 
-	var ip16 [MaxIPSize]byte
+	var ip16 [net.IPv6len]byte
 	ipBytes := []byte(ip)
 	if len(ip) != net.IPv6len {
 		if err := validateIPTo(ip, ip16[:]); err != nil {
@@ -444,15 +445,28 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 
 	// Determine if this is IPv4
 	isIPv4 := ip.To4() != nil
-	if err := validateOutputLength(encrypted, MaxIPSize, "encrypted"); err != nil {
-		return nil, err
+	encryptedBits := encrypted
+	if isIPv4 {
+		switch len(encrypted) {
+		case net.IPv6len:
+			encryptedBits = encrypted[:net.IPv6len]
+			copy(encryptedBits[:12], ipv4MappedPrefix[:])
+		case net.IPv4len:
+			encryptedBits = encrypted[:net.IPv4len]
+		default:
+			return nil, fmt.Errorf("invalid encrypted parameter: got %d bytes, want %d bytes for IPv4 or %d bytes for IPv6", len(encrypted), net.IPv4len, net.IPv6len)
+		}
+	} else {
+		if err := validateOutputLength(encrypted, net.IPv6len, "encrypted"); err != nil {
+			return nil, err
+		}
+		encryptedBits = encrypted[:net.IPv6len]
 	}
 
 	// Determine starting point
 	prefixStart := 0
 	if isIPv4 {
 		prefixStart = 96
-		copy(encrypted[:12], ipv4MappedPrefix[:])
 	}
 
 	// Initialize padded prefix for the starting prefix length
@@ -482,7 +496,7 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 		originalBit := getBit(ipBytes, currentBitPos)
 
 		// Set the bit in the encrypted result
-		setBit(encrypted, currentBitPos, cipherBit^originalBit)
+		setBit(encryptedBits, currentBitPos, cipherBit^originalBit)
 
 		// Prepare padded_prefix for next iteration
 		// Shift left by 1 bit and insert the next bit from ipBytes
@@ -490,7 +504,7 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 		setBit(paddedPrefix, 0, originalBit)
 	}
 
-	return net.IP(encrypted), nil
+	return net.IP(encryptedBits), nil
 }
 
 // EncryptIPPfx encrypts an IP address using ipcrypt-pfx mode.
@@ -500,16 +514,26 @@ func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
 	if len(key) != 32 {
 		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
 	}
-	encrypted := make([]byte, MaxIPSize)
+	var encrypted []byte
+	switch len(ip) {
+	case net.IPv6len:
+		encrypted = make([]byte, net.IPv6len)
+	case net.IPv4len:
+		encrypted = make([]byte, net.IPv4len)
+	default:
+		return nil, fmt.Errorf("invalid ip parameter length (%d bytes) - must be either %d bytes or %d bytes", len(ip), net.IPv4len, net.IPv6len)
+	}
 	scratch := ScratchPad{}
 	return EncryptIPPfxTo(ip, key, encrypted, &scratch)
 }
 
 // DecryptIPPfxTo decrypts an IP address that was encrypted using ipcrypt-pfx mode.
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
-// The decrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The decrypted parameter must be exactly net.IPv4len bytes for IPv4 inputs or exactly
+// net.IPv6len bytes for IPv6 inputs.
 // The scratch parameter provides reusable state to avoid allocations across calls.
-// Returns the decrypted IP address.
+// Returns the decrypted IP address in net.IPv4len-byte form for IPv4 callers using a net.IPv4len-byte
+// destination buffer, or 16-byte form otherwise.
 func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if scratch == nil {
 		return nil, errors.New("scratch parameter must not be nil")
@@ -531,12 +555,28 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 	// Keep IPv4 ciphertexts in their IPv4 code path, but normalize them to
 	// the 16-byte IPv4-mapped form before the bitwise decryption loop.
 	isIPv4 := encryptedIP.To4() != nil
-	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
-		return nil, err
+	decryptedBits := decrypted
+	if isIPv4 {
+		switch len(decrypted) {
+		case net.IPv6len:
+			decryptedBits = decrypted[:net.IPv6len]
+			copy(decryptedBits[:12], ipv4MappedPrefix[:])
+		case net.IPv4len:
+			decryptedBits = decrypted[:net.IPv4len]
+		default:
+			return nil, fmt.Errorf("invalid decrypted parameter: got %d bytes, want %d bytes for IPv4 or %d bytes for IPv6", len(decrypted), net.IPv4len, net.IPv6len)
+		}
+	} else {
+		if err := validateOutputLength(decrypted, net.IPv6len, "decrypted"); err != nil {
+			return nil, err
+		}
+		decryptedBits = decrypted[:net.IPv6len]
 	}
-	var encryptedIP16 [MaxIPSize]byte
+	var encryptedIP16 [net.IPv6len]byte
 	encryptedBytes := []byte(encryptedIP)
-	if len(encryptedIP) != net.IPv6len {
+	if isIPv4 && len(encryptedIP) == net.IPv4len {
+		encryptedBytes = encryptedIP
+	} else if len(encryptedIP) != net.IPv6len {
 		if err := validateIPTo(encryptedIP, encryptedIP16[:]); err != nil {
 			return nil, err
 		}
@@ -558,7 +598,6 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 	prefixStart := 0
 	if isIPv4 {
 		prefixStart = 96
-		copy(decrypted[:12], ipv4MappedPrefix[:])
 	}
 
 	// Initialize padded prefix for the starting prefix length
@@ -589,7 +628,7 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 		originalBit := cipherBit ^ encryptedBit
 
 		// Set the bit in the decrypted result
-		setBit(decrypted, currentBitPos, originalBit)
+		setBit(decryptedBits, currentBitPos, originalBit)
 
 		// Prepare padded_prefix for next iteration
 		// Shift left by 1 bit and insert the next bit from decrypted
@@ -597,32 +636,40 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 		setBit(paddedPrefix, 0, originalBit)
 	}
 
-	return net.IP(decrypted), nil
+	return net.IP(decryptedBits), nil
 }
 
 // DecryptIPPfx decrypts an IP address that was encrypted using ipcrypt-pfx mode.
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
 // Returns the decrypted IP address.
 func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
-	decrypted := make([]byte, MaxIPSize)
+	var decrypted []byte
+	switch len(encryptedIP) {
+	case net.IPv6len:
+		decrypted = make([]byte, net.IPv6len)
+	case net.IPv4len:
+		decrypted = make([]byte, net.IPv4len)
+	default:
+		return nil, fmt.Errorf("invalid encryptedIP parameter length (%d bytes) - must be either %d bytes or %d bytes", len(encryptedIP), net.IPv4len, net.IPv6len)
+	}
 	scratch := ScratchPad{}
 	return DecryptIPPfxTo(encryptedIP, key, decrypted, &scratch)
 }
 
 // Helper functions for bit manipulation
 
-// getBit extracts bit at position from 16-byte array
-// position: 0 = LSB of byte 15, 127 = MSB of byte 0
+// getBit extracts a bit at position from the supplied byte slice.
+// position: 0 = LSB of the final byte, len(data)*8-1 = MSB of the first byte.
 func getBit(data []byte, position int) byte {
-	byteIndex := 15 - (position / 8)
+	byteIndex := len(data) - 1 - (position / 8)
 	bitIndex := position % 8
 	return (data[byteIndex] >> bitIndex) & 1
 }
 
-// setBit sets bit at position in 16-byte array
-// position: 0 = LSB of byte 15, 127 = MSB of byte 0
+// setBit sets a bit at position in the supplied byte slice.
+// position: 0 = LSB of the final byte, len(data)*8-1 = MSB of the first byte.
 func setBit(data []byte, position int, value byte) {
-	byteIndex := 15 - (position / 8)
+	byteIndex := len(data) - 1 - (position / 8)
 	bitIndex := position % 8
 	if value != 0 {
 		data[byteIndex] |= 1 << bitIndex
@@ -655,7 +702,7 @@ func shiftLeftOneBit(data []byte) {
 // EncryptIPNonDeterministicXTo encrypts an IP address using ipcrypt-ndx mode.
 // The key must be exactly KeySizeNDX bytes long.
 // If tweak is nil, a random tweak will be generated.
-// The encrypted parameter must be a byte slice of minimum NonDeterministicXSize bytes long.
+// The encrypted parameter must be exactly NonDeterministicXSize bytes long.
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
 func EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error) {
@@ -735,7 +782,7 @@ func EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, er
 
 // DecryptIPNonDeterministicXTo decrypts an IP address that was encrypted using ipcrypt-ndx mode.
 // The key must be exactly KeySizeNDX bytes long.
-// The decrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The decrypted parameter must be exactly net.IPv6len bytes long.
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
 func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
@@ -751,7 +798,7 @@ func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byt
 		return nil, fmt.Errorf("invalid ciphertext length: got %d, want %d", len(ciphertext), NonDeterministicXSize)
 	}
 
-	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
+	if err := validateOutputLength(decrypted, net.IPv6len, "decrypted"); err != nil {
 		return nil, err
 	}
 
@@ -787,14 +834,14 @@ func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byt
 	}
 
 	copy(decrypted, finalDecrypted)
-	return net.IP(decrypted[:MaxIPSize]), nil
+	return net.IP(decrypted[:net.IPv6len]), nil
 }
 
 // DecryptIPNonDeterministicX decrypts an IP address that was encrypted using ipcrypt-ndx mode.
 // The key must be exactly KeySizeNDX bytes long.
 // Returns the decrypted IP address as a string.
 func DecryptIPNonDeterministicX(ciphertext []byte, key []byte) (string, error) {
-	decrypted := make([]byte, MaxIPSize)
+	decrypted := make([]byte, net.IPv6len)
 	scratch := ScratchPad{}
 	ip, err := DecryptIPNonDeterministicXTo(ciphertext, key, decrypted, &scratch)
 	if err != nil {

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -10,6 +10,7 @@ package ipcrypt
 
 import (
 	"crypto/aes"
+	"crypto/cipher"
 	"crypto/rand"
 	"crypto/subtle"
 	"errors"
@@ -32,14 +33,15 @@ const (
 
 // Max length of an encrypted or decrypted IP address
 const (
-	MaxIPLength           = 16 // Maximum length of an encrypted IP address in bytes
-	NonDeterministicSize  = TweakSize + MaxIPLength
-	NonDeterministicXSize = TweakSizeX + MaxIPLength
+	MaxIPSize             = 16 // Maximum size of an encrypted IP address in bytes
+	MaxScratchSize        = 16 // Maximum scratch buffer size in bytes
+	NonDeterministicSize  = TweakSize + MaxIPSize
+	NonDeterministicXSize = TweakSizeX + MaxIPSize
 )
 
 var (
-	pfxIPv4PaddedPrefix = [MaxIPLength]byte{3: 0x01, 14: 0xFF, 15: 0xFF}
-	pfxIPv6PaddedPrefix = [MaxIPLength]byte{15: 0x01}
+	pfxIPv4PaddedPrefix = [MaxIPSize]byte{3: 0x01, 14: 0xFF, 15: 0xFF}
+	pfxIPv6PaddedPrefix = [MaxIPSize]byte{15: 0x01}
 )
 
 // Error definitions for the package
@@ -51,40 +53,95 @@ var (
 
 // ScratchPad enables reuse of byte slices during encryption and decryption operations to avoid allocations
 type ScratchPad struct {
-	Scratch1 []byte
-	Scratch2 []byte
-	Scratch3 []byte
-	Scratch4 []byte
-}
+	Scratch1 [MaxScratchSize]byte
+	Scratch2 [MaxScratchSize]byte
+	Scratch3 [MaxScratchSize]byte
+	Scratch4 [MaxScratchSize]byte
 
-// init initializes the scratchpad with empty byte slices of the appropriate size if necessary
-func (s *ScratchPad) init() {
-	if s.Scratch1 == nil {
-		s.Scratch1 = make([]byte, MaxIPLength)
-	}
-	if s.Scratch2 == nil {
-		s.Scratch2 = make([]byte, MaxIPLength)
-	}
-	if s.Scratch3 == nil {
-		s.Scratch3 = make([]byte, MaxIPLength)
-	}
-	if s.Scratch4 == nil {
-		s.Scratch4 = make([]byte, MaxIPLength)
-	}
+	keySlot1 [aes.BlockSize]byte
+	keySlot2 [aes.BlockSize]byte
+
+	blockSlot1 cipher.Block
+	blockSlot2 cipher.Block
+
+	// The saved key slots start as all-zero bytes, so an all-zero key would be
+	// indistinguishable from the zero value without an explicit readiness bit.
+	blockSlot1Ready bool
+	blockSlot2Ready bool
+
+	roundKeys1 [11][16]byte
+	roundKeys2 [11][16]byte
+	// The cached round key arrays also have a meaningful all-zero zero value, so
+	// a separate readiness bit is required before relying on key equality.
+	roundKeys1Ready bool
+	roundKeys2Ready bool
 }
 
 func getScratchPad(scratch *ScratchPad) *ScratchPad {
 	if scratch == nil {
 		return NewScratchPad()
 	}
-	scratch.init()
 	return scratch
 }
 
+func (s *ScratchPad) getAESBlock(slot int, key []byte) (cipher.Block, error) {
+	if len(key) != aes.BlockSize {
+		return nil, fmt.Errorf("%w: got %d bytes, want %d bytes", ErrInvalidKeySize, len(key), aes.BlockSize)
+	}
+
+	switch slot {
+	case 1:
+		if s.blockSlot1Ready && subtle.ConstantTimeCompare(s.keySlot1[:], key) == 1 {
+			return s.blockSlot1, nil
+		}
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return nil, err
+		}
+		copy(s.keySlot1[:], key)
+		s.blockSlot1 = block
+		s.blockSlot1Ready = true
+		return block, nil
+	case 2:
+		if s.blockSlot2Ready && subtle.ConstantTimeCompare(s.keySlot2[:], key) == 1 {
+			return s.blockSlot2, nil
+		}
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return nil, err
+		}
+		copy(s.keySlot2[:], key)
+		s.blockSlot2 = block
+		s.blockSlot2Ready = true
+		return block, nil
+	default:
+		return nil, errors.New("invalid AES block slot")
+	}
+}
+
+func (s *ScratchPad) getRoundKeys(slot int, key []byte) *[11][16]byte {
+	switch slot {
+	case 1:
+		if !s.roundKeys1Ready || subtle.ConstantTimeCompare(s.keySlot1[:], key) != 1 {
+			expandKeyTo(key, &s.roundKeys1)
+			copy(s.keySlot1[:], key)
+			s.roundKeys1Ready = true
+		}
+		return &s.roundKeys1
+	case 2:
+		if !s.roundKeys2Ready || subtle.ConstantTimeCompare(s.keySlot2[:], key) != 1 {
+			expandKeyTo(key, &s.roundKeys2)
+			copy(s.keySlot2[:], key)
+			s.roundKeys2Ready = true
+		}
+		return &s.roundKeys2
+	default:
+		panic("invalid round key slot")
+	}
+}
+
 func NewScratchPad() *ScratchPad {
-	s := ScratchPad{}
-	s.init()
-	return &s
+	return &ScratchPad{}
 }
 
 // Utility functions
@@ -142,16 +199,17 @@ func validateOutputLength(buf []byte, expectedSize int, parameterName string) er
 
 // Deterministic mode functions
 
-// EncryptIP encrypts an IP address using ipcrypt-deterministic mode.
+// EncryptIPTo EncryptIP encrypts an IP address using ipcrypt-deterministic mode.
 // The key must be exactly KeySizeDeterministic bytes long.
-// The encrypted parameter must be a byte slice of minimum MaxIPLength bytes long
+// The encrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the encrypted IP address as a net.IP.
-func EncryptIPTo(key []byte, ip net.IP, encrypted []byte) (net.IP, error) {
+func EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if err := validateKey(key, KeySizeDeterministic); err != nil {
 		return nil, err
 	}
 
-	if err := validateOutputLength(encrypted, MaxIPLength, "encrypted"); err != nil {
+	if err := validateOutputLength(encrypted, MaxIPSize, "encrypted"); err != nil {
 		return nil, err
 	}
 
@@ -160,7 +218,8 @@ func EncryptIPTo(key []byte, ip net.IP, encrypted []byte) (net.IP, error) {
 		return nil, err
 	}
 
-	block, err := aes.NewCipher(key)
+	scratch = getScratchPad(scratch)
+	block, err := scratch.getAESBlock(1, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
 	}
@@ -175,19 +234,20 @@ func EncryptIPTo(key []byte, ip net.IP, encrypted []byte) (net.IP, error) {
 // Returns the encrypted IP address as a net.IP.
 func EncryptIP(key []byte, ip net.IP) (net.IP, error) {
 	encrypted := make([]byte, 16)
-	return EncryptIPTo(key, ip, encrypted)
+	return EncryptIPTo(key, ip, encrypted, nil)
 }
 
-// DecryptIP decrypts an IP address that was encrypted using ipcrypt-deterministic mode.
+// DecryptIPTo DecryptIP decrypts an IP address that was encrypted using ipcrypt-deterministic mode.
 // The key must be exactly KeySizeDeterministic bytes long.
-// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long
+// The decrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
-func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte) (net.IP, error) {
+func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if err := validateKey(key, KeySizeDeterministic); err != nil {
 		return nil, err
 	}
 
-	if err := validateOutputLength(decrypted, MaxIPLength, "decrypted"); err != nil {
+	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
 		return nil, err
 	}
 
@@ -196,7 +256,8 @@ func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte) (net.IP, error)
 		return nil, err
 	}
 
-	block, err := aes.NewCipher(key)
+	scratch = getScratchPad(scratch)
+	block, err := scratch.getAESBlock(1, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
 	}
@@ -211,17 +272,18 @@ func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte) (net.IP, error)
 // Returns the decrypted IP address as a net.IP.
 func DecryptIP(key []byte, encrypted net.IP) (net.IP, error) {
 	decrypted := make([]byte, 16)
-	return DecryptIPTo(key, encrypted, decrypted)
+	return DecryptIPTo(key, encrypted, decrypted, nil)
 }
 
 // Non-deterministic mode functions
 
-// EncryptIPNonDeterministic encrypts an IP address using ipcrypt-nd mode.
+// EncryptIPNonDeterministicTo EncryptIPNonDeterministic encrypts an IP address using ipcrypt-nd mode.
 // The key must be exactly KeySizeND bytes long.
 // If tweak is nil, a random tweak will be generated.
 // The encrypted parameter must be a byte slice of minimum NonDeterministicSize bytes long.
+// The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
-func EncryptIPNonDeterministicTo(ip string, key []byte, tweak []byte, encrypted []byte) ([]byte, error) {
+func EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error) {
 	if err := validateKey(key, KeySizeND); err != nil {
 		return nil, err
 	}
@@ -230,10 +292,11 @@ func EncryptIPNonDeterministicTo(ip string, key []byte, tweak []byte, encrypted 
 		return nil, err
 	}
 
-	ipBytes, err := validateIP(net.ParseIP(ip))
+	ipBytes, err := validateIP(ip)
 	if err != nil {
 		return nil, err
 	}
+	scratch = getScratchPad(scratch)
 
 	var t []byte
 	if tweak == nil {
@@ -249,12 +312,10 @@ func EncryptIPNonDeterministicTo(ip string, key []byte, tweak []byte, encrypted 
 		copy(encrypted[:TweakSize], t)
 	}
 
-	ciphertext, err := KiasuBCEncrypt(key, t, ipBytes)
-	if err != nil {
+	roundKeys := scratch.getRoundKeys(1, key)
+	if err := kiasuBCEncryptTo(roundKeys, t, ipBytes, encrypted[TweakSize:], scratch.Scratch1[:]); err != nil {
 		return nil, err
 	}
-
-	copy(encrypted[TweakSize:], ciphertext)
 	return encrypted[:NonDeterministicSize], nil
 }
 
@@ -264,14 +325,15 @@ func EncryptIPNonDeterministicTo(ip string, key []byte, tweak []byte, encrypted 
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
 func EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, error) {
 	encrypted := make([]byte, NonDeterministicSize)
-	return EncryptIPNonDeterministicTo(ip, key, tweak, encrypted)
+	return EncryptIPNonDeterministicTo(net.ParseIP(ip), key, tweak, encrypted, nil)
 }
 
 // DecryptIPNonDeterministicTo decrypts an IP address that was encrypted using ipcrypt-nd mode.
 // The key must be exactly KeySizeND bytes long.
-// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// The decrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
-func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte) (net.IP, error) {
+func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if err := validateKey(key, KeySizeND); err != nil {
 		return nil, err
 	}
@@ -280,28 +342,27 @@ func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte
 		return nil, fmt.Errorf("invalid ciphertext length: got %d, want %d", len(ciphertext), NonDeterministicSize)
 	}
 
-	if err := validateOutputLength(decrypted, MaxIPLength, "decrypted"); err != nil {
+	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
 		return nil, err
 	}
+	scratch = getScratchPad(scratch)
 
 	tweak := ciphertext[:TweakSize]
 	encryptedIP := ciphertext[TweakSize:]
 
-	plainIP, err := KiasuBCDecrypt(key, tweak, encryptedIP)
-	if err != nil {
+	roundKeys := scratch.getRoundKeys(1, key)
+	if err := kiasuBCDecryptTo(roundKeys, tweak, encryptedIP, decrypted, scratch.Scratch1[:]); err != nil {
 		return nil, err
 	}
-
-	copy(decrypted, plainIP)
-	return net.IP(decrypted[:MaxIPLength]), nil
+	return net.IP(decrypted[:MaxIPSize]), nil
 }
 
 // DecryptIPNonDeterministic decrypts an IP address that was encrypted using ipcrypt-nd mode.
 // The key must be exactly KeySizeND bytes long.
 // Returns the decrypted IP address as a string.
 func DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error) {
-	decrypted := make([]byte, MaxIPLength)
-	ip, err := DecryptIPNonDeterministicTo(ciphertext, key, decrypted)
+	decrypted := make([]byte, MaxIPSize)
+	ip, err := DecryptIPNonDeterministicTo(ciphertext, key, decrypted, nil)
 	if err != nil {
 		return "", err
 	}
@@ -313,17 +374,10 @@ func DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error) {
 
 // EncryptIPPfxTo encrypts an IP address using ipcrypt-pfx mode.
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
-// The encrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// The encrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the encrypted IP address in 16-byte form.
-func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte) (net.IP, error) {
-	return EncryptIPPfxToScratch(ip, key, encrypted, nil)
-}
-
-// EncryptIPPfxToScratch encrypts an IP address using ipcrypt-pfx mode using the provided scratchpad to avoid allocations.
-// The key must be exactly 32 bytes long (split into two AES-128 keys).
-// The encrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
-// Returns the encrypted IP address in 16-byte form.
-func EncryptIPPfxToScratch(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error) {
+func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if len(key) != 32 {
 		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
 	}
@@ -343,25 +397,26 @@ func EncryptIPPfxToScratch(ip net.IP, key []byte, encrypted []byte, scratch *Scr
 		return nil, err
 	}
 
+	scratch = getScratchPad(scratch)
+
 	// Create AES cipher objects
-	cipher1, err := aes.NewCipher(k1)
+	cipher1, err := scratch.getAESBlock(1, k1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create first cipher: %w", err)
 	}
 
-	cipher2, err := aes.NewCipher(k2)
+	cipher2, err := scratch.getAESBlock(2, k2)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create second cipher: %w", err)
 	}
 
 	// Determine if this is IPv4
 	isIPv4 := ip.To4() != nil
-	if err := validateOutputLength(encrypted, MaxIPLength, "encrypted"); err != nil {
+	if err := validateOutputLength(encrypted, MaxIPSize, "encrypted"); err != nil {
 		return nil, err
 	}
-	scratch = getScratchPad(scratch)
 
-	encrypted = encrypted[:MaxIPLength]
+	encrypted = encrypted[:MaxIPSize]
 
 	// Determine starting point
 	prefixStart := 0
@@ -372,7 +427,7 @@ func EncryptIPPfxToScratch(ip net.IP, key []byte, encrypted []byte, scratch *Scr
 	}
 
 	// Initialize padded prefix for the starting prefix length
-	paddedPrefix := scratch.Scratch1[:MaxIPLength]
+	paddedPrefix := scratch.Scratch1[:]
 	if isIPv4 {
 		copy(paddedPrefix, pfxIPv4PaddedPrefix[:])
 	} else {
@@ -382,14 +437,14 @@ func EncryptIPPfxToScratch(ip net.IP, key []byte, encrypted []byte, scratch *Scr
 	// Process each bit position
 	for prefixLenBits := prefixStart; prefixLenBits < 128; prefixLenBits++ {
 		// Compute pseudorandom function with dual AES encryption
-		e1 := scratch.Scratch2[:MaxIPLength]
+		e1 := scratch.Scratch2[:]
 		cipher1.Encrypt(e1, paddedPrefix)
 
-		e2 := scratch.Scratch3[:MaxIPLength]
+		e2 := scratch.Scratch3[:]
 		cipher2.Encrypt(e2, paddedPrefix)
 
 		// XOR the two encryptions
-		e := xorBytesTo(e1, e2, scratch.Scratch4[:MaxIPLength])
+		e := xorBytesTo(e1, e2, scratch.Scratch4[:])
 		// We only need the least significant bit
 		cipherBit := e[15] & 1
 
@@ -413,23 +468,16 @@ func EncryptIPPfxToScratch(ip net.IP, key []byte, encrypted []byte, scratch *Scr
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
 // Returns the encrypted IP address maintaining the original format (IPv4 or IPv6).
 func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
-	encrypted := make([]byte, MaxIPLength)
-	return EncryptIPPfxTo(ip, key, encrypted)
+	encrypted := make([]byte, MaxIPSize)
+	return EncryptIPPfxTo(ip, key, encrypted, nil)
 }
 
 // DecryptIPPfxTo decrypts an IP address that was encrypted using ipcrypt-pfx mode.
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
-// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
-// Returns the decrypted IP address
-func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte) (net.IP, error) {
-	return DecryptIPPfxToScratch(encryptedIP, key, decrypted, nil)
-}
-
-// DecryptIPPfxToScratch decrypts an IP address that was encrypted using ipcrypt-pfx mode using the provided scratchpad to avoid allocations.
-// The key must be exactly 32 bytes long (split into two AES-128 keys).
-// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
-// Returns the decrypted IP address
-func DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
+// The decrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The scratch parameter provides reusable state to avoid allocations across calls.
+// Returns the decrypted IP address.
+func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if len(key) != 32 {
 		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
 	}
@@ -446,7 +494,7 @@ func DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scr
 	// Keep IPv4 ciphertexts in their IPv4 code path, but normalize them to
 	// the 16-byte IPv4-mapped form before the bitwise decryption loop.
 	isIPv4 := encryptedIP.To4() != nil
-	if err := validateOutputLength(decrypted, MaxIPLength, "decrypted"); err != nil {
+	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
 		return nil, err
 	}
 	scratch = getScratchPad(scratch)
@@ -457,17 +505,17 @@ func DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scr
 	}
 
 	// Create AES cipher objects
-	cipher1, err := aes.NewCipher(k1)
+	cipher1, err := scratch.getAESBlock(1, k1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create first cipher: %w", err)
 	}
 
-	cipher2, err := aes.NewCipher(k2)
+	cipher2, err := scratch.getAESBlock(2, k2)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create second cipher: %w", err)
 	}
 
-	decrypted = decrypted[:MaxIPLength]
+	decrypted = decrypted[:MaxIPSize]
 
 	// Determine starting point
 	prefixStart := 0
@@ -478,7 +526,7 @@ func DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scr
 	}
 
 	// Initialize padded prefix for the starting prefix length
-	paddedPrefix := scratch.Scratch1[:MaxIPLength]
+	paddedPrefix := scratch.Scratch1[:]
 	if isIPv4 {
 		copy(paddedPrefix, pfxIPv4PaddedPrefix[:])
 	} else {
@@ -488,14 +536,14 @@ func DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scr
 	// Process each bit position
 	for prefixLenBits := prefixStart; prefixLenBits < 128; prefixLenBits++ {
 		// Compute pseudorandom function with dual AES encryption
-		e1 := scratch.Scratch2[:MaxIPLength]
+		e1 := scratch.Scratch2[:]
 		cipher1.Encrypt(e1, paddedPrefix)
 
-		e2 := scratch.Scratch3[:MaxIPLength]
+		e2 := scratch.Scratch3[:]
 		cipher2.Encrypt(e2, paddedPrefix)
 
 		// XOR the two encryptions
-		e := xorBytesTo(e1, e2, scratch.Scratch4[:MaxIPLength])
+		e := xorBytesTo(e1, e2, scratch.Scratch4[:])
 		// We only need the least significant bit
 		cipherBit := e[15] & 1
 
@@ -520,8 +568,8 @@ func DecryptIPPfxToScratch(encryptedIP net.IP, key []byte, decrypted []byte, scr
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
 // Returns the decrypted IP address.
 func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
-	decrypted := make([]byte, MaxIPLength)
-	return DecryptIPPfxTo(encryptedIP, key, decrypted)
+	decrypted := make([]byte, MaxIPSize)
+	return DecryptIPPfxTo(encryptedIP, key, decrypted, nil)
 }
 
 // Helper functions for bit manipulation
@@ -571,17 +619,9 @@ func shiftLeftOneBit(data []byte) {
 // The key must be exactly KeySizeNDX bytes long.
 // If tweak is nil, a random tweak will be generated.
 // The encrypted parameter must be a byte slice of minimum NonDeterministicXSize bytes long.
+// The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
-func EncryptIPNonDeterministicXTo(ip string, key []byte, tweak []byte, encrypted []byte) ([]byte, error) {
-	return EncryptIPNonDeterministicXToScratch(ip, key, tweak, encrypted, nil)
-}
-
-// EncryptIPNonDeterministicXToScratch encrypts an IP address using ipcrypt-ndx mode using the provided scratchpad to avoid allocations.
-// The key must be exactly KeySizeNDX bytes long.
-// If tweak is nil, a random tweak will be generated.
-// The encrypted parameter must be a byte slice of minimum NonDeterministicXSize bytes long.
-// Returns a byte slice containing the tweak concatenated with the encrypted IP.
-func EncryptIPNonDeterministicXToScratch(ip string, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error) {
+func EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error) {
 	if err := validateKey(key, KeySizeNDX); err != nil {
 		return nil, err
 	}
@@ -591,7 +631,7 @@ func EncryptIPNonDeterministicXToScratch(ip string, key []byte, tweak []byte, en
 	}
 	scratch = getScratchPad(scratch)
 
-	ipBytes, err := validateIP(net.ParseIP(ip))
+	ipBytes, err := validateIP(ip)
 	if err != nil {
 		return nil, err
 	}
@@ -599,12 +639,12 @@ func EncryptIPNonDeterministicXToScratch(ip string, key []byte, tweak []byte, en
 	key1 := key[:KeySizeND]
 	key2 := key[KeySizeND:]
 
-	block1, err := aes.NewCipher(key1)
+	block1, err := scratch.getAESBlock(1, key1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create first cipher: %w", err)
 	}
 
-	block2, err := aes.NewCipher(key2)
+	block2, err := scratch.getAESBlock(2, key2)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create second cipher: %w", err)
 	}
@@ -623,17 +663,17 @@ func EncryptIPNonDeterministicXToScratch(ip string, key []byte, tweak []byte, en
 		copy(encrypted[:TweakSizeX], t)
 	}
 
-	encryptedTweak := scratch.Scratch1[:MaxIPLength]
+	encryptedTweak := scratch.Scratch1[:]
 	block2.Encrypt(encryptedTweak, t)
 
-	xoredIP := xorBytesTo(ipBytes, encryptedTweak, scratch.Scratch2[:MaxIPLength])
+	xoredIP := xorBytesTo(ipBytes, encryptedTweak, scratch.Scratch2[:])
 	if xoredIP == nil {
 		return nil, errors.New("XOR operation failed")
 	}
 
 	block1.Encrypt(encrypted[TweakSizeX:], xoredIP)
 
-	finalEncrypted := xorBytesTo(encrypted[TweakSizeX:], encryptedTweak, scratch.Scratch3[:MaxIPLength])
+	finalEncrypted := xorBytesTo(encrypted[TweakSizeX:], encryptedTweak, scratch.Scratch3[:])
 	if finalEncrypted == nil {
 		return nil, errors.New("XOR operation failed")
 	}
@@ -648,22 +688,15 @@ func EncryptIPNonDeterministicXToScratch(ip string, key []byte, tweak []byte, en
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
 func EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, error) {
 	encrypted := make([]byte, NonDeterministicXSize)
-	return EncryptIPNonDeterministicXTo(ip, key, tweak, encrypted)
+	return EncryptIPNonDeterministicXTo(net.ParseIP(ip), key, tweak, encrypted, nil)
 }
 
 // DecryptIPNonDeterministicXTo decrypts an IP address that was encrypted using ipcrypt-ndx mode.
 // The key must be exactly KeySizeNDX bytes long.
-// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
+// The decrypted parameter must be a byte slice of minimum MaxIPSize bytes long.
+// The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
-func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte) (net.IP, error) {
-	return DecryptIPNonDeterministicXToScratch(ciphertext, key, decrypted, nil)
-}
-
-// DecryptIPNonDeterministicXToScratch decrypts an IP address that was encrypted using ipcrypt-ndx mode using the provided scratchpad to avoid allocations.
-// The key must be exactly KeySizeNDX bytes long.
-// The decrypted parameter must be a byte slice of minimum MaxIPLength bytes long.
-// Returns the decrypted IP address as a net.IP.
-func DecryptIPNonDeterministicXToScratch(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
+func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
 	if err := validateKey(key, KeySizeNDX); err != nil {
 		return nil, err
 	}
@@ -672,7 +705,7 @@ func DecryptIPNonDeterministicXToScratch(ciphertext []byte, key []byte, decrypte
 		return nil, fmt.Errorf("invalid ciphertext length: got %d, want %d", len(ciphertext), NonDeterministicXSize)
 	}
 
-	if err := validateOutputLength(decrypted, MaxIPLength, "decrypted"); err != nil {
+	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
 		return nil, err
 	}
 	scratch = getScratchPad(scratch)
@@ -680,12 +713,12 @@ func DecryptIPNonDeterministicXToScratch(ciphertext []byte, key []byte, decrypte
 	key1 := key[:KeySizeND]
 	key2 := key[KeySizeND:]
 
-	block1, err := aes.NewCipher(key1)
+	block1, err := scratch.getAESBlock(1, key1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create first cipher: %w", err)
 	}
 
-	block2, err := aes.NewCipher(key2)
+	block2, err := scratch.getAESBlock(2, key2)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create second cipher: %w", err)
 	}
@@ -693,31 +726,31 @@ func DecryptIPNonDeterministicXToScratch(ciphertext []byte, key []byte, decrypte
 	tweak := ciphertext[:TweakSizeX]
 	encryptedIP := ciphertext[TweakSizeX:]
 
-	encryptedTweak := scratch.Scratch1[:MaxIPLength]
+	encryptedTweak := scratch.Scratch1[:]
 	block2.Encrypt(encryptedTweak, tweak)
 
-	xoredIP := xorBytesTo(encryptedIP, encryptedTweak, scratch.Scratch2[:MaxIPLength])
+	xoredIP := xorBytesTo(encryptedIP, encryptedTweak, scratch.Scratch2[:])
 	if xoredIP == nil {
 		return nil, errors.New("XOR operation failed")
 	}
 
 	block1.Decrypt(decrypted, xoredIP)
 
-	finalDecrypted := xorBytesTo(decrypted, encryptedTweak, scratch.Scratch3[:MaxIPLength])
+	finalDecrypted := xorBytesTo(decrypted, encryptedTweak, scratch.Scratch3[:])
 	if finalDecrypted == nil {
 		return nil, errors.New("XOR operation failed")
 	}
 
 	copy(decrypted, finalDecrypted)
-	return net.IP(decrypted[:MaxIPLength]), nil
+	return net.IP(decrypted[:MaxIPSize]), nil
 }
 
 // DecryptIPNonDeterministicX decrypts an IP address that was encrypted using ipcrypt-ndx mode.
 // The key must be exactly KeySizeNDX bytes long.
 // Returns the decrypted IP address as a string.
 func DecryptIPNonDeterministicX(ciphertext []byte, key []byte) (string, error) {
-	decrypted := make([]byte, MaxIPLength)
-	ip, err := DecryptIPNonDeterministicXTo(ciphertext, key, decrypted)
+	decrypted := make([]byte, MaxIPSize)
+	ip, err := DecryptIPNonDeterministicXTo(ciphertext, key, decrypted, nil)
 	if err != nil {
 		return "", err
 	}

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -42,6 +42,7 @@ const (
 var (
 	pfxIPv4PaddedPrefix = [MaxIPSize]byte{3: 0x01, 14: 0xFF, 15: 0xFF}
 	pfxIPv6PaddedPrefix = [MaxIPSize]byte{15: 0x01}
+	ipv4MappedPrefix    = [12]byte{10: 0xFF, 11: 0xFF}
 )
 
 // Error definitions for the package
@@ -75,13 +76,6 @@ type ScratchPad struct {
 	// a separate readiness bit is required before relying on key equality.
 	roundKeys1Ready bool
 	roundKeys2Ready bool
-}
-
-func getScratchPad(scratch *ScratchPad) *ScratchPad {
-	if scratch == nil {
-		return NewScratchPad()
-	}
-	return scratch
 }
 
 func (s *ScratchPad) getAESBlock(slot int, key []byte) (cipher.Block, error) {
@@ -154,16 +148,24 @@ func validateKey(key []byte, expectedSize int) error {
 	return nil
 }
 
-// validateIP ensures the IP address is valid and can be converted to 16-byte form
-func validateIP(ip net.IP) ([]byte, error) {
+// validateIPTo ensures the IP address is valid and writes its 16-byte form to dst.
+func validateIPTo(ip net.IP, dst []byte) error {
 	if ip == nil {
-		return nil, ErrInvalidIP
+		return ErrInvalidIP
 	}
-	ip16 := ip.To16()
-	if ip16 == nil {
-		return nil, ErrInvalidIP
+
+	if len(ip) == net.IPv6len {
+		copy(dst, ip)
+		return nil
 	}
-	return ip16, nil
+
+	if len(ip) == net.IPv4len {
+		copy(dst[:len(ipv4MappedPrefix)], ipv4MappedPrefix[:])
+		copy(dst[len(ipv4MappedPrefix):], ip)
+		return nil
+	}
+
+	return ErrInvalidIP
 }
 
 // validateTweak checks if the tweak length matches the expected size
@@ -205,6 +207,10 @@ func validateOutputLength(buf []byte, expectedSize int, parameterName string) er
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the encrypted IP address as a net.IP.
 func EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (net.IP, error) {
+	if scratch == nil {
+		return nil, errors.New("scratch parameter must not be nil")
+	}
+
 	if err := validateKey(key, KeySizeDeterministic); err != nil {
 		return nil, err
 	}
@@ -213,12 +219,14 @@ func EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (
 		return nil, err
 	}
 
-	ipBytes, err := validateIP(ip)
-	if err != nil {
-		return nil, err
+	ipBytes := []byte(ip)
+	if len(ip) != net.IPv6len {
+		if err := validateIPTo(ip, scratch.Scratch1[:MaxIPSize]); err != nil {
+			return nil, err
+		}
+		ipBytes = encrypted[:MaxIPSize]
 	}
 
-	scratch = getScratchPad(scratch)
 	block, err := scratch.getAESBlock(1, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
@@ -234,7 +242,8 @@ func EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (
 // Returns the encrypted IP address as a net.IP.
 func EncryptIP(key []byte, ip net.IP) (net.IP, error) {
 	encrypted := make([]byte, 16)
-	return EncryptIPTo(key, ip, encrypted, nil)
+	scratch := ScratchPad{}
+	return EncryptIPTo(key, ip, encrypted, &scratch)
 }
 
 // DecryptIPTo DecryptIP decrypts an IP address that was encrypted using ipcrypt-deterministic mode.
@@ -243,6 +252,10 @@ func EncryptIP(key []byte, ip net.IP) (net.IP, error) {
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
 func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
+	if scratch == nil {
+		return nil, errors.New("scratch parameter must not be nil")
+	}
+
 	if err := validateKey(key, KeySizeDeterministic); err != nil {
 		return nil, err
 	}
@@ -251,12 +264,14 @@ func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *Scratc
 		return nil, err
 	}
 
-	ipBytes, err := validateIP(encrypted)
-	if err != nil {
-		return nil, err
+	ipBytes := []byte(encrypted)
+	if len(encrypted) != net.IPv6len {
+		if err := validateIPTo(encrypted, scratch.Scratch1[:MaxIPSize]); err != nil {
+			return nil, err
+		}
+		ipBytes = decrypted[:MaxIPSize]
 	}
 
-	scratch = getScratchPad(scratch)
 	block, err := scratch.getAESBlock(1, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
@@ -272,7 +287,8 @@ func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *Scratc
 // Returns the decrypted IP address as a net.IP.
 func DecryptIP(key []byte, encrypted net.IP) (net.IP, error) {
 	decrypted := make([]byte, 16)
-	return DecryptIPTo(key, encrypted, decrypted, nil)
+	scratch := ScratchPad{}
+	return DecryptIPTo(key, encrypted, decrypted, &scratch)
 }
 
 // Non-deterministic mode functions
@@ -284,6 +300,10 @@ func DecryptIP(key []byte, encrypted net.IP) (net.IP, error) {
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
 func EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error) {
+	if scratch == nil {
+		return nil, errors.New("scratch parameter must not be nil")
+	}
+
 	if err := validateKey(key, KeySizeND); err != nil {
 		return nil, err
 	}
@@ -292,11 +312,13 @@ func EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted 
 		return nil, err
 	}
 
-	ipBytes, err := validateIP(ip)
-	if err != nil {
-		return nil, err
+	ipBytes := []byte(ip)
+	if len(ip) != net.IPv6len {
+		if err := validateIPTo(ip, scratch.Scratch1[:MaxIPSize]); err != nil {
+			return nil, err
+		}
+		ipBytes = scratch.Scratch1[:MaxIPSize]
 	}
-	scratch = getScratchPad(scratch)
 
 	var t []byte
 	if tweak == nil {
@@ -325,7 +347,8 @@ func EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted 
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
 func EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, error) {
 	encrypted := make([]byte, NonDeterministicSize)
-	return EncryptIPNonDeterministicTo(net.ParseIP(ip), key, tweak, encrypted, nil)
+	scratch := ScratchPad{}
+	return EncryptIPNonDeterministicTo(net.ParseIP(ip), key, tweak, encrypted, &scratch)
 }
 
 // DecryptIPNonDeterministicTo decrypts an IP address that was encrypted using ipcrypt-nd mode.
@@ -334,6 +357,10 @@ func EncryptIPNonDeterministic(ip string, key []byte, tweak []byte) ([]byte, err
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
 func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
+	if scratch == nil {
+		return nil, errors.New("scratch parameter must not be nil")
+	}
+
 	if err := validateKey(key, KeySizeND); err != nil {
 		return nil, err
 	}
@@ -345,7 +372,6 @@ func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte
 	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
 		return nil, err
 	}
-	scratch = getScratchPad(scratch)
 
 	tweak := ciphertext[:TweakSize]
 	encryptedIP := ciphertext[TweakSize:]
@@ -362,7 +388,8 @@ func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte
 // Returns the decrypted IP address as a string.
 func DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error) {
 	decrypted := make([]byte, MaxIPSize)
-	ip, err := DecryptIPNonDeterministicTo(ciphertext, key, decrypted, nil)
+	scratch := ScratchPad{}
+	ip, err := DecryptIPNonDeterministicTo(ciphertext, key, decrypted, &scratch)
 	if err != nil {
 		return "", err
 	}
@@ -378,6 +405,10 @@ func DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error) {
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the encrypted IP address in 16-byte form.
 func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad) (net.IP, error) {
+	if scratch == nil {
+		return nil, errors.New("scratch parameter must not be nil")
+	}
+
 	if len(key) != 32 {
 		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
 	}
@@ -391,13 +422,14 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 		return nil, errors.New("the two halves of the key must be different")
 	}
 
-	// Convert IP to 16-byte representation
-	ipBytes, err := validateIP(ip)
-	if err != nil {
-		return nil, err
+	var ip16 [MaxIPSize]byte
+	ipBytes := []byte(ip)
+	if len(ip) != net.IPv6len {
+		if err := validateIPTo(ip, ip16[:]); err != nil {
+			return nil, err
+		}
+		ipBytes = ip16[:]
 	}
-
-	scratch = getScratchPad(scratch)
 
 	// Create AES cipher objects
 	cipher1, err := scratch.getAESBlock(1, k1)
@@ -422,8 +454,7 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 	prefixStart := 0
 	if isIPv4 {
 		prefixStart = 96
-		// Copy the IPv4-mapped prefix
-		copy(encrypted[:12], ipBytes[:12])
+		copy(encrypted[:12], ipv4MappedPrefix[:])
 	}
 
 	// Initialize padded prefix for the starting prefix length
@@ -469,7 +500,8 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 // Returns the encrypted IP address maintaining the original format (IPv4 or IPv6).
 func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
 	encrypted := make([]byte, MaxIPSize)
-	return EncryptIPPfxTo(ip, key, encrypted, nil)
+	scratch := ScratchPad{}
+	return EncryptIPPfxTo(ip, key, encrypted, &scratch)
 }
 
 // DecryptIPPfxTo decrypts an IP address that was encrypted using ipcrypt-pfx mode.
@@ -478,6 +510,10 @@ func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address.
 func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
+	if scratch == nil {
+		return nil, errors.New("scratch parameter must not be nil")
+	}
+
 	if len(key) != 32 {
 		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
 	}
@@ -497,11 +533,13 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
 		return nil, err
 	}
-	scratch = getScratchPad(scratch)
-
-	encryptedBytes, err := validateIP(encryptedIP)
-	if err != nil {
-		return nil, err
+	var encryptedIP16 [MaxIPSize]byte
+	encryptedBytes := []byte(encryptedIP)
+	if len(encryptedIP) != net.IPv6len {
+		if err := validateIPTo(encryptedIP, encryptedIP16[:]); err != nil {
+			return nil, err
+		}
+		encryptedBytes = encryptedIP16[:]
 	}
 
 	// Create AES cipher objects
@@ -521,8 +559,7 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 	prefixStart := 0
 	if isIPv4 {
 		prefixStart = 96
-		// Copy the IPv4-mapped prefix
-		copy(decrypted[:12], encryptedBytes[:12])
+		copy(decrypted[:12], ipv4MappedPrefix[:])
 	}
 
 	// Initialize padded prefix for the starting prefix length
@@ -569,7 +606,8 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 // Returns the decrypted IP address.
 func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
 	decrypted := make([]byte, MaxIPSize)
-	return DecryptIPPfxTo(encryptedIP, key, decrypted, nil)
+	scratch := ScratchPad{}
+	return DecryptIPPfxTo(encryptedIP, key, decrypted, &scratch)
 }
 
 // Helper functions for bit manipulation
@@ -622,6 +660,9 @@ func shiftLeftOneBit(data []byte) {
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
 func EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted []byte, scratch *ScratchPad) ([]byte, error) {
+	if scratch == nil {
+		return nil, errors.New("scratch parameter must not be nil")
+	}
 	if err := validateKey(key, KeySizeNDX); err != nil {
 		return nil, err
 	}
@@ -629,11 +670,12 @@ func EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted
 	if err := validateOutputLength(encrypted, NonDeterministicXSize, "encrypted"); err != nil {
 		return nil, err
 	}
-	scratch = getScratchPad(scratch)
-
-	ipBytes, err := validateIP(ip)
-	if err != nil {
-		return nil, err
+	ipBytes := []byte(ip)
+	if len(ip) != net.IPv6len {
+		if err := validateIPTo(ip, scratch.Scratch4[:]); err != nil {
+			return nil, err
+		}
+		ipBytes = scratch.Scratch4[:]
 	}
 
 	key1 := key[:KeySizeND]
@@ -688,7 +730,8 @@ func EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted
 // Returns a byte slice containing the tweak concatenated with the encrypted IP.
 func EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, error) {
 	encrypted := make([]byte, NonDeterministicXSize)
-	return EncryptIPNonDeterministicXTo(net.ParseIP(ip), key, tweak, encrypted, nil)
+	scratch := ScratchPad{}
+	return EncryptIPNonDeterministicXTo(net.ParseIP(ip), key, tweak, encrypted, &scratch)
 }
 
 // DecryptIPNonDeterministicXTo decrypts an IP address that was encrypted using ipcrypt-ndx mode.
@@ -697,6 +740,10 @@ func EncryptIPNonDeterministicX(ip string, key []byte, tweak []byte) ([]byte, er
 // The scratch parameter provides reusable state to avoid allocations across calls.
 // Returns the decrypted IP address as a net.IP.
 func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byte, scratch *ScratchPad) (net.IP, error) {
+	if scratch == nil {
+		return nil, errors.New("scratch parameter must not be nil")
+	}
+
 	if err := validateKey(key, KeySizeNDX); err != nil {
 		return nil, err
 	}
@@ -708,7 +755,6 @@ func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byt
 	if err := validateOutputLength(decrypted, MaxIPSize, "decrypted"); err != nil {
 		return nil, err
 	}
-	scratch = getScratchPad(scratch)
 
 	key1 := key[:KeySizeND]
 	key2 := key[KeySizeND:]
@@ -750,7 +796,8 @@ func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byt
 // Returns the decrypted IP address as a string.
 func DecryptIPNonDeterministicX(ciphertext []byte, key []byte) (string, error) {
 	decrypted := make([]byte, MaxIPSize)
-	ip, err := DecryptIPNonDeterministicXTo(ciphertext, key, decrypted, nil)
+	scratch := ScratchPad{}
+	ip, err := DecryptIPNonDeterministicXTo(ciphertext, key, decrypted, &scratch)
 	if err != nil {
 		return "", err
 	}

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -23,6 +23,7 @@ const (
 	KeySizeDeterministic = 16 // Size in bytes of the key for ipcrypt-deterministic mode
 	KeySizeND            = 16 // Size in bytes of the key for ipcrypt-nd mode
 	KeySizeNDX           = 32 // Size in bytes of the key for ipcrypt-ndx mode
+	KeySizePFX           = 32 // Size in bytes of the key for ipcrypt-pfx mode
 )
 
 // Tweak sizes for different encryption modes
@@ -399,7 +400,7 @@ func DecryptIPNonDeterministic(ciphertext []byte, key []byte) (string, error) {
 // Prefix-preserving mode functions
 
 // EncryptIPPfxTo encrypts an IP address using ipcrypt-pfx mode.
-// The key must be exactly 32 bytes long (split into two AES-128 keys).
+// The key must be exactly KeySizePFX bytes long (split into two AES-128 keys).
 // The encrypted parameter must be exactly net.IPv4len bytes for IPv4 inputs or exactly
 // net.IPv6len bytes for IPv6 inputs.
 // The scratch parameter provides reusable state to avoid allocations across calls.
@@ -410,13 +411,13 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 		return nil, errors.New("scratch parameter must not be nil")
 	}
 
-	if len(key) != 32 {
-		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
+	if err := validateKey(key, KeySizePFX); err != nil {
+		return nil, err
 	}
 
 	// Split the key into two AES-128 keys
-	k1 := key[:16]
-	k2 := key[16:32]
+	k1 := key[:aes.BlockSize]
+	k2 := key[aes.BlockSize:KeySizePFX]
 
 	// Check that K1 and K2 are different
 	if subtle.ConstantTimeCompare(k1, k2) == 1 {
@@ -508,11 +509,11 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 }
 
 // EncryptIPPfx encrypts an IP address using ipcrypt-pfx mode.
-// The key must be exactly 32 bytes long (split into two AES-128 keys).
+// The key must be exactly KeySizePFX bytes long (split into two AES-128 keys).
 // Returns the encrypted IP address maintaining the original format (IPv4 or IPv6).
 func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
-	if len(key) != 32 {
-		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
+	if err := validateKey(key, KeySizePFX); err != nil {
+		return nil, err
 	}
 	var encrypted []byte
 	switch len(ip) {
@@ -528,7 +529,7 @@ func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
 }
 
 // DecryptIPPfxTo decrypts an IP address that was encrypted using ipcrypt-pfx mode.
-// The key must be exactly 32 bytes long (split into two AES-128 keys).
+// The key must be exactly KeySizePFX bytes long (split into two AES-128 keys).
 // The decrypted parameter must be exactly net.IPv4len bytes for IPv4 inputs or exactly
 // net.IPv6len bytes for IPv6 inputs.
 // The scratch parameter provides reusable state to avoid allocations across calls.
@@ -539,13 +540,13 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 		return nil, errors.New("scratch parameter must not be nil")
 	}
 
-	if len(key) != 32 {
-		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
+	if err := validateKey(key, KeySizePFX); err != nil {
+		return nil, err
 	}
 
 	// Split the key into two AES-128 keys
-	k1 := key[:16]
-	k2 := key[16:32]
+	k1 := key[:aes.BlockSize]
+	k2 := key[aes.BlockSize:KeySizePFX]
 
 	// Check that K1 and K2 are different
 	if subtle.ConstantTimeCompare(k1, k2) == 1 {
@@ -640,7 +641,7 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 }
 
 // DecryptIPPfx decrypts an IP address that was encrypted using ipcrypt-pfx mode.
-// The key must be exactly 32 bytes long (split into two AES-128 keys).
+// The key must be exactly KeySizePFX bytes long (split into two AES-128 keys).
 // Returns the decrypted IP address.
 func DecryptIPPfx(encryptedIP net.IP, key []byte) (net.IP, error) {
 	var decrypted []byte

--- a/ipcrypt.go
+++ b/ipcrypt.go
@@ -54,10 +54,10 @@ var (
 
 // ScratchPad enables reuse of byte slices during encryption and decryption operations to avoid allocations
 type ScratchPad struct {
-	Scratch1 [MaxScratchSize]byte
-	Scratch2 [MaxScratchSize]byte
-	Scratch3 [MaxScratchSize]byte
-	Scratch4 [MaxScratchSize]byte
+	scratch1 [MaxScratchSize]byte
+	scratch2 [MaxScratchSize]byte
+	scratch3 [MaxScratchSize]byte
+	scratch4 [MaxScratchSize]byte
 
 	keySlot1 [aes.BlockSize]byte
 	keySlot2 [aes.BlockSize]byte
@@ -221,10 +221,10 @@ func EncryptIPTo(key []byte, ip net.IP, encrypted []byte, scratch *ScratchPad) (
 
 	ipBytes := []byte(ip)
 	if len(ip) != net.IPv6len {
-		if err := validateIPTo(ip, scratch.Scratch1[:MaxIPSize]); err != nil {
+		if err := validateIPTo(ip, scratch.scratch1[:MaxIPSize]); err != nil {
 			return nil, err
 		}
-		ipBytes = encrypted[:MaxIPSize]
+		ipBytes = scratch.scratch1[:MaxIPSize]
 	}
 
 	block, err := scratch.getAESBlock(1, key)
@@ -266,10 +266,10 @@ func DecryptIPTo(key []byte, encrypted net.IP, decrypted []byte, scratch *Scratc
 
 	ipBytes := []byte(encrypted)
 	if len(encrypted) != net.IPv6len {
-		if err := validateIPTo(encrypted, scratch.Scratch1[:MaxIPSize]); err != nil {
+		if err := validateIPTo(encrypted, scratch.scratch1[:MaxIPSize]); err != nil {
 			return nil, err
 		}
-		ipBytes = decrypted[:MaxIPSize]
+		ipBytes = scratch.scratch1[:MaxIPSize]
 	}
 
 	block, err := scratch.getAESBlock(1, key)
@@ -314,10 +314,10 @@ func EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted 
 
 	ipBytes := []byte(ip)
 	if len(ip) != net.IPv6len {
-		if err := validateIPTo(ip, scratch.Scratch1[:MaxIPSize]); err != nil {
+		if err := validateIPTo(ip, scratch.scratch1[:MaxIPSize]); err != nil {
 			return nil, err
 		}
-		ipBytes = scratch.Scratch1[:MaxIPSize]
+		ipBytes = scratch.scratch1[:MaxIPSize]
 	}
 
 	var t []byte
@@ -335,7 +335,7 @@ func EncryptIPNonDeterministicTo(ip net.IP, key []byte, tweak []byte, encrypted 
 	}
 
 	roundKeys := scratch.getRoundKeys(1, key)
-	if err := kiasuBCEncryptTo(roundKeys, t, ipBytes, encrypted[TweakSize:], scratch.Scratch1[:]); err != nil {
+	if err := kiasuBCEncryptTo(roundKeys, t, ipBytes, encrypted[TweakSize:], scratch.scratch1[:]); err != nil {
 		return nil, err
 	}
 	return encrypted[:NonDeterministicSize], nil
@@ -377,7 +377,7 @@ func DecryptIPNonDeterministicTo(ciphertext []byte, key []byte, decrypted []byte
 	encryptedIP := ciphertext[TweakSize:]
 
 	roundKeys := scratch.getRoundKeys(1, key)
-	if err := kiasuBCDecryptTo(roundKeys, tweak, encryptedIP, decrypted, scratch.Scratch1[:]); err != nil {
+	if err := kiasuBCDecryptTo(roundKeys, tweak, encryptedIP, decrypted, scratch.scratch1[:]); err != nil {
 		return nil, err
 	}
 	return net.IP(decrypted[:MaxIPSize]), nil
@@ -447,9 +447,7 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 	if err := validateOutputLength(encrypted, MaxIPSize, "encrypted"); err != nil {
 		return nil, err
 	}
-
-	encrypted = encrypted[:MaxIPSize]
-
+	
 	// Determine starting point
 	prefixStart := 0
 	if isIPv4 {
@@ -458,7 +456,7 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 	}
 
 	// Initialize padded prefix for the starting prefix length
-	paddedPrefix := scratch.Scratch1[:]
+	paddedPrefix := scratch.scratch1[:]
 	if isIPv4 {
 		copy(paddedPrefix, pfxIPv4PaddedPrefix[:])
 	} else {
@@ -468,14 +466,14 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 	// Process each bit position
 	for prefixLenBits := prefixStart; prefixLenBits < 128; prefixLenBits++ {
 		// Compute pseudorandom function with dual AES encryption
-		e1 := scratch.Scratch2[:]
+		e1 := scratch.scratch2[:]
 		cipher1.Encrypt(e1, paddedPrefix)
 
-		e2 := scratch.Scratch3[:]
+		e2 := scratch.scratch3[:]
 		cipher2.Encrypt(e2, paddedPrefix)
 
 		// XOR the two encryptions
-		e := xorBytesTo(e1, e2, scratch.Scratch4[:])
+		e := xorBytesTo(e1, e2, scratch.scratch4[:])
 		// We only need the least significant bit
 		cipherBit := e[15] & 1
 
@@ -499,6 +497,9 @@ func EncryptIPPfxTo(ip net.IP, key []byte, encrypted []byte, scratch *ScratchPad
 // The key must be exactly 32 bytes long (split into two AES-128 keys).
 // Returns the encrypted IP address maintaining the original format (IPv4 or IPv6).
 func EncryptIPPfx(ip net.IP, key []byte) (net.IP, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("%w: got %d bytes, want 32 bytes", ErrInvalidKeySize, len(key))
+	}
 	encrypted := make([]byte, MaxIPSize)
 	scratch := ScratchPad{}
 	return EncryptIPPfxTo(ip, key, encrypted, &scratch)
@@ -553,8 +554,6 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 		return nil, fmt.Errorf("failed to create second cipher: %w", err)
 	}
 
-	decrypted = decrypted[:MaxIPSize]
-
 	// Determine starting point
 	prefixStart := 0
 	if isIPv4 {
@@ -563,7 +562,7 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 	}
 
 	// Initialize padded prefix for the starting prefix length
-	paddedPrefix := scratch.Scratch1[:]
+	paddedPrefix := scratch.scratch1[:]
 	if isIPv4 {
 		copy(paddedPrefix, pfxIPv4PaddedPrefix[:])
 	} else {
@@ -573,14 +572,14 @@ func DecryptIPPfxTo(encryptedIP net.IP, key []byte, decrypted []byte, scratch *S
 	// Process each bit position
 	for prefixLenBits := prefixStart; prefixLenBits < 128; prefixLenBits++ {
 		// Compute pseudorandom function with dual AES encryption
-		e1 := scratch.Scratch2[:]
+		e1 := scratch.scratch2[:]
 		cipher1.Encrypt(e1, paddedPrefix)
 
-		e2 := scratch.Scratch3[:]
+		e2 := scratch.scratch3[:]
 		cipher2.Encrypt(e2, paddedPrefix)
 
 		// XOR the two encryptions
-		e := xorBytesTo(e1, e2, scratch.Scratch4[:])
+		e := xorBytesTo(e1, e2, scratch.scratch4[:])
 		// We only need the least significant bit
 		cipherBit := e[15] & 1
 
@@ -672,10 +671,10 @@ func EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted
 	}
 	ipBytes := []byte(ip)
 	if len(ip) != net.IPv6len {
-		if err := validateIPTo(ip, scratch.Scratch4[:]); err != nil {
+		if err := validateIPTo(ip, scratch.scratch4[:]); err != nil {
 			return nil, err
 		}
-		ipBytes = scratch.Scratch4[:]
+		ipBytes = scratch.scratch4[:]
 	}
 
 	key1 := key[:KeySizeND]
@@ -705,17 +704,17 @@ func EncryptIPNonDeterministicXTo(ip net.IP, key []byte, tweak []byte, encrypted
 		copy(encrypted[:TweakSizeX], t)
 	}
 
-	encryptedTweak := scratch.Scratch1[:]
+	encryptedTweak := scratch.scratch1[:]
 	block2.Encrypt(encryptedTweak, t)
 
-	xoredIP := xorBytesTo(ipBytes, encryptedTweak, scratch.Scratch2[:])
+	xoredIP := xorBytesTo(ipBytes, encryptedTweak, scratch.scratch2[:])
 	if xoredIP == nil {
 		return nil, errors.New("XOR operation failed")
 	}
 
 	block1.Encrypt(encrypted[TweakSizeX:], xoredIP)
 
-	finalEncrypted := xorBytesTo(encrypted[TweakSizeX:], encryptedTweak, scratch.Scratch3[:])
+	finalEncrypted := xorBytesTo(encrypted[TweakSizeX:], encryptedTweak, scratch.scratch3[:])
 	if finalEncrypted == nil {
 		return nil, errors.New("XOR operation failed")
 	}
@@ -772,17 +771,17 @@ func DecryptIPNonDeterministicXTo(ciphertext []byte, key []byte, decrypted []byt
 	tweak := ciphertext[:TweakSizeX]
 	encryptedIP := ciphertext[TweakSizeX:]
 
-	encryptedTweak := scratch.Scratch1[:]
+	encryptedTweak := scratch.scratch1[:]
 	block2.Encrypt(encryptedTweak, tweak)
 
-	xoredIP := xorBytesTo(encryptedIP, encryptedTweak, scratch.Scratch2[:])
+	xoredIP := xorBytesTo(encryptedIP, encryptedTweak, scratch.scratch2[:])
 	if xoredIP == nil {
 		return nil, errors.New("XOR operation failed")
 	}
 
 	block1.Decrypt(decrypted, xoredIP)
 
-	finalDecrypted := xorBytesTo(decrypted, encryptedTweak, scratch.Scratch3[:])
+	finalDecrypted := xorBytesTo(decrypted, encryptedTweak, scratch.scratch3[:])
 	if finalDecrypted == nil {
 		return nil, errors.New("XOR operation failed")
 	}

--- a/ipcrypt_test.go
+++ b/ipcrypt_test.go
@@ -552,6 +552,23 @@ func TestDecryptIPPfxAcceptsFourByteEncryptedIPv4(t *testing.T) {
 	}
 }
 
+func TestIPPfxRejectsInvalidIPParameterLength(t *testing.T) {
+	key, err := hex.DecodeString("0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301")
+	if err != nil {
+		t.Fatalf("Failed to decode key: %v", err)
+	}
+
+	invalidIP := net.IP{1, 2, 3, 4, 5}
+
+	if _, err := EncryptIPPfx(invalidIP, key); err == nil || !strings.Contains(err.Error(), "invalid ip parameter length") {
+		t.Fatalf("expected invalid ip length error from EncryptIPPfx, got %v", err)
+	}
+
+	if _, err := DecryptIPPfx(invalidIP, key); err == nil || !strings.Contains(err.Error(), "invalid encryptedIP parameter length") {
+		t.Fatalf("expected invalid encryptedIP length error from DecryptIPPfx, got %v", err)
+	}
+}
+
 func TestEncryptIPToRejectsNonExactBufferLength(t *testing.T) {
 	key, _ := hex.DecodeString("1032547698badcfeefcdab8967452301")
 	scratch := NewScratchPad()

--- a/ipcrypt_test.go
+++ b/ipcrypt_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 	"testing"
 )
@@ -1147,17 +1148,26 @@ func benchmarkCasesFromTestVectors(b *testing.B, variant string) []benchmarkVect
 			continue
 		}
 
-		ip := net.ParseIP(tv.ip)
-		if ip == nil {
+		addr, err := netip.ParseAddr(tv.ip)
+		if err != nil {
 			b.Fatalf("invalid benchmark IP in test vector: %s", tv.ip)
 		}
 
-		isIPv4 := ip.To4() != nil
+		isIPv4 := addr.Is4()
 		if isIPv4 && haveIPv4 {
 			continue
 		}
 		if !isIPv4 && haveIPv6 {
 			continue
+		}
+
+		var ip net.IP
+		if isIPv4 {
+			temp := addr.As4()
+			ip = temp[:]
+		} else {
+			temp := addr.As16()
+			ip = temp[:]
 		}
 
 		key, err := hex.DecodeString(tv.key)

--- a/ipcrypt_test.go
+++ b/ipcrypt_test.go
@@ -975,7 +975,7 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range deterministicCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					ip, err := EncryptIP(tc.key, tc.ip)
 					if err != nil {
 						b.Fatal(err)
@@ -995,7 +995,7 @@ func BenchmarkAllocations(b *testing.B) {
 					b.Fatal(err)
 				}
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					ip, err := EncryptIPTo(tc.key, tc.ip, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
@@ -1010,7 +1010,7 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range deterministicCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					ip, err := DecryptIP(tc.key, tc.cipherIP)
 					if err != nil {
 						b.Fatal(err)
@@ -1030,7 +1030,7 @@ func BenchmarkAllocations(b *testing.B) {
 					b.Fatal(err)
 				}
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					ip, err := DecryptIPTo(tc.key, tc.cipherIP, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
@@ -1045,7 +1045,7 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range ndCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := EncryptIPNonDeterministic(tc.ipString, tc.key, tc.tweak)
 					if err != nil {
 						b.Fatal(err)
@@ -1062,7 +1062,7 @@ func BenchmarkAllocations(b *testing.B) {
 				buf := make([]byte, NonDeterministicSize)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := EncryptIPNonDeterministicTo(tc.ip, tc.key, tc.tweak, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
@@ -1077,7 +1077,7 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range ndCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := DecryptIPNonDeterministic(tc.ciphertext, tc.key)
 					if err != nil {
 						b.Fatal(err)
@@ -1094,7 +1094,7 @@ func BenchmarkAllocations(b *testing.B) {
 				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := DecryptIPNonDeterministicTo(tc.ciphertext, tc.key, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
@@ -1109,7 +1109,7 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range ndxCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := EncryptIPNonDeterministicX(tc.ipString, tc.key, tc.tweak)
 					if err != nil {
 						b.Fatal(err)
@@ -1126,7 +1126,7 @@ func BenchmarkAllocations(b *testing.B) {
 				buf := make([]byte, NonDeterministicXSize)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := EncryptIPNonDeterministicXTo(tc.ip, tc.key, tc.tweak, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
@@ -1141,7 +1141,7 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range ndxCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := DecryptIPNonDeterministicX(tc.ciphertext, tc.key)
 					if err != nil {
 						b.Fatal(err)
@@ -1158,7 +1158,7 @@ func BenchmarkAllocations(b *testing.B) {
 				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := DecryptIPNonDeterministicXTo(tc.ciphertext, tc.key, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
@@ -1173,7 +1173,7 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range pfxCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := EncryptIPPfx(tc.ip, tc.key)
 					if err != nil {
 						b.Fatal(err)
@@ -1190,7 +1190,7 @@ func BenchmarkAllocations(b *testing.B) {
 				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := EncryptIPPfxTo(tc.ip, tc.key, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
@@ -1205,7 +1205,7 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range pfxCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := DecryptIPPfx(tc.cipherIP, tc.key)
 					if err != nil {
 						b.Fatal(err)
@@ -1222,7 +1222,7 @@ func BenchmarkAllocations(b *testing.B) {
 				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
-				for b.Loop() {
+				for i := 0; i < b.N; i++ {
 					out, err := DecryptIPPfxTo(tc.cipherIP, tc.key, buf, scratch)
 					if err != nil {
 						b.Fatal(err)

--- a/ipcrypt_test.go
+++ b/ipcrypt_test.go
@@ -21,6 +21,23 @@ type testVector struct {
 	output  string
 }
 
+func mustParseIPPreserveWidth(t testing.TB, s string) net.IP {
+	t.Helper()
+
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		t.Fatalf("invalid IP address: %s", s)
+	}
+
+	if addr.Is4() {
+		ip := addr.As4()
+		return net.IP(ip[:])
+	}
+
+	ip := addr.As16()
+	return net.IP(ip[:])
+}
+
 var testVectors = []testVector{
 	// ipcrypt-deterministic test vectors
 	{
@@ -138,10 +155,7 @@ func TestReferenceVectors(t *testing.T) {
 	for _, tv := range testVectors {
 		t.Run(tv.variant+"/"+tv.ip, func(t *testing.T) {
 			// Parse input IP
-			ip := net.ParseIP(tv.ip)
-			if ip == nil {
-				t.Fatalf("Invalid IP address: %s", tv.ip)
-			}
+			ip := mustParseIPPreserveWidth(t, tv.ip)
 
 			// Parse key
 			key, err := hex.DecodeString(tv.key)
@@ -466,7 +480,7 @@ func TestIPNonDeterministicX(t *testing.T) {
 // generateRandomIP generates a random IPv4 address.
 func generateRandomIP(t *testing.T) string {
 	t.Helper()
-	b := make([]byte, 4)
+	b := make([]byte, net.IPv4len)
 	if _, err := rand.Read(b); err != nil {
 		t.Fatalf("Failed to generate random bytes: %v", err)
 	}
@@ -513,23 +527,52 @@ func TestDecryptIPPfxAcceptsFourByteEncryptedIPv4(t *testing.T) {
 		t.Fatalf("Failed to decode key: %v", err)
 	}
 
-	ip := net.ParseIP("192.0.2.1")
-	if ip == nil {
-		t.Fatal("Failed to parse IP")
-	}
+	ip := mustParseIPPreserveWidth(t, "192.0.2.1")
 
 	encrypted, err := EncryptIPPfx(ip, key)
 	if err != nil {
 		t.Fatalf("EncryptIPPfx failed: %v", err)
 	}
 
+	if len(encrypted) != net.IPv4len {
+		t.Fatalf("Expected encrypted IP to be %d bytes not %d bytes for a %d-byte input IP", net.IPv4len, len(encrypted), net.IPv4len)
+	}
+
 	decrypted, err := DecryptIPPfx(encrypted.To4(), key)
 	if err != nil {
-		t.Fatalf("DecryptIPPfx failed for 4-byte encrypted IPv4: %v", err)
+		t.Fatalf("DecryptIPPfx failed for %d-byte encrypted IPv4: %v", net.IPv4len, err)
+	}
+
+	if len(decrypted) != net.IPv4len {
+		t.Fatalf("Expected decrypted IP to be %d bytes not %d bytes for a %d-byte input IP", net.IPv4len, len(decrypted), net.IPv4len)
 	}
 
 	if !decrypted.Equal(ip) {
 		t.Fatalf("Decryption failed: got %s, want %s", decrypted, ip)
+	}
+}
+
+func TestEncryptIPToRejectsNonExactBufferLength(t *testing.T) {
+	key, _ := hex.DecodeString("1032547698badcfeefcdab8967452301")
+	scratch := NewScratchPad()
+
+	if _, err := EncryptIPTo(key, net.ParseIP("192.0.2.1"), make([]byte, net.IPv6len-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected short-buffer error, got %v", err)
+	}
+	if _, err := EncryptIPTo(key, net.ParseIP("192.0.2.1"), make([]byte, net.IPv6len+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected oversized-buffer error, got %v", err)
+	}
+}
+
+func TestDecryptIPToRejectsNonExactBufferLength(t *testing.T) {
+	key, _ := hex.DecodeString("1032547698badcfeefcdab8967452301")
+	scratch := NewScratchPad()
+
+	if _, err := DecryptIPTo(key, net.ParseIP("30.93.34.67"), make([]byte, net.IPv6len-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected short-buffer error, got %v", err)
+	}
+	if _, err := DecryptIPTo(key, net.ParseIP("30.93.34.67"), make([]byte, net.IPv6len+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected oversized-buffer error, got %v", err)
 	}
 }
 
@@ -555,6 +598,9 @@ func TestEncryptIPNonDeterministicTo(t *testing.T) {
 	if _, err := EncryptIPNonDeterministicTo(net.ParseIP("192.0.2.1"), key, tweak, make([]byte, NonDeterministicSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
 		t.Fatalf("expected short-buffer error, got %v", err)
 	}
+	if _, err := EncryptIPNonDeterministicTo(net.ParseIP("192.0.2.1"), key, tweak, make([]byte, NonDeterministicSize+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected oversized-buffer error, got %v", err)
+	}
 }
 
 func TestDecryptIPNonDeterministicTo(t *testing.T) {
@@ -562,7 +608,7 @@ func TestDecryptIPNonDeterministicTo(t *testing.T) {
 	ciphertext, _ := hex.DecodeString("21bd1834bc088cd2e5e1fe55f95876e639faae2594a0caad")
 	scratch := NewScratchPad()
 
-	buf := make([]byte, MaxIPSize)
+	buf := make([]byte, net.IPv6len)
 	decrypted, err := DecryptIPNonDeterministicTo(ciphertext, key, buf, scratch)
 	if err != nil {
 		t.Fatalf("DecryptIPNonDeterministicTo failed: %v", err)
@@ -576,8 +622,11 @@ func TestDecryptIPNonDeterministicTo(t *testing.T) {
 		t.Fatalf("DecryptIPNonDeterministicTo mismatch: got %s", decrypted)
 	}
 
-	if _, err := DecryptIPNonDeterministicTo(ciphertext, key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+	if _, err := DecryptIPNonDeterministicTo(ciphertext, key, make([]byte, net.IPv6len-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
 		t.Fatalf("expected short-buffer error, got %v", err)
+	}
+	if _, err := DecryptIPNonDeterministicTo(ciphertext, key, make([]byte, net.IPv6len+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected oversized-buffer error, got %v", err)
 	}
 }
 
@@ -585,19 +634,22 @@ func TestEncryptIPPfxTo(t *testing.T) {
 	key, _ := hex.DecodeString("0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301")
 	scratch := NewScratchPad()
 
-	ipv4Buf := make([]byte, MaxIPSize)
-	encryptedIPv4, err := EncryptIPPfxTo(net.ParseIP("192.0.2.1"), key, ipv4Buf, scratch)
+	ipv4Buf := make([]byte, net.IPv4len)
+	encryptedIPv4, err := EncryptIPPfxTo(mustParseIPPreserveWidth(t, "192.0.2.1"), key, ipv4Buf, scratch)
 	if err != nil {
 		t.Fatalf("EncryptIPPfxTo IPv4 failed: %v", err)
 	}
 	if &encryptedIPv4[0] != &ipv4Buf[0] {
 		t.Fatal("EncryptIPPfxTo IPv4 did not reuse caller buffer")
 	}
+	if len(encryptedIPv4) != net.IPv4len {
+		t.Fatalf("EncryptIPPfxTo IPv4 returned %d bytes, want %d", len(encryptedIPv4), net.IPv4len)
+	}
 	if got := encryptedIPv4.String(); got != "100.115.72.131" {
 		t.Fatalf("EncryptIPPfxTo IPv4 mismatch: got %s", got)
 	}
 
-	ipv6Buf := make([]byte, MaxIPSize)
+	ipv6Buf := make([]byte, net.IPv6len)
 	encryptedIPv6, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, ipv6Buf, scratch)
 	if err != nil {
 		t.Fatalf("EncryptIPPfxTo IPv6 failed: %v", err)
@@ -609,11 +661,17 @@ func TestEncryptIPPfxTo(t *testing.T) {
 		t.Fatalf("EncryptIPPfxTo IPv6 mismatch: got %s", got)
 	}
 
-	if _, err := EncryptIPPfxTo(net.ParseIP("192.0.2.1"), key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+	if _, err := EncryptIPPfxTo(mustParseIPPreserveWidth(t, "192.0.2.1"), key, make([]byte, net.IPv4len-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
 		t.Fatalf("expected short IPv4 buffer error, got %v", err)
 	}
-	if _, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+	if _, err := EncryptIPPfxTo(mustParseIPPreserveWidth(t, "192.0.2.1"), key, make([]byte, net.IPv4len+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected oversized IPv4 buffer error, got %v", err)
+	}
+	if _, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, make([]byte, net.IPv6len-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
 		t.Fatalf("expected short IPv6 buffer error, got %v", err)
+	}
+	if _, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, make([]byte, net.IPv6len+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected oversized IPv6 buffer error, got %v", err)
 	}
 }
 
@@ -621,19 +679,22 @@ func TestDecryptIPPfxTo(t *testing.T) {
 	key, _ := hex.DecodeString("0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301")
 	scratch := NewScratchPad()
 
-	ipv4Buf := make([]byte, MaxIPSize)
-	decryptedIPv4, err := DecryptIPPfxTo(net.ParseIP("100.115.72.131").To4(), key, ipv4Buf, scratch)
+	ipv4Buf := make([]byte, net.IPv4len)
+	decryptedIPv4, err := DecryptIPPfxTo(mustParseIPPreserveWidth(t, "100.115.72.131"), key, ipv4Buf, scratch)
 	if err != nil {
 		t.Fatalf("DecryptIPPfxTo IPv4 failed: %v", err)
 	}
 	if &decryptedIPv4[0] != &ipv4Buf[0] {
 		t.Fatal("DecryptIPPfxTo IPv4 did not reuse caller buffer")
 	}
+	if len(decryptedIPv4) != net.IPv4len {
+		t.Fatalf("DecryptIPPfxTo IPv4 returned %d bytes, want %d", len(decryptedIPv4), net.IPv4len)
+	}
 	if got := decryptedIPv4.String(); got != "192.0.2.1" {
 		t.Fatalf("DecryptIPPfxTo IPv4 mismatch: got %s", got)
 	}
 
-	ipv6Buf := make([]byte, MaxIPSize)
+	ipv6Buf := make([]byte, net.IPv6len)
 	decryptedIPv6, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, ipv6Buf, scratch)
 	if err != nil {
 		t.Fatalf("DecryptIPPfxTo IPv6 failed: %v", err)
@@ -645,11 +706,17 @@ func TestDecryptIPPfxTo(t *testing.T) {
 		t.Fatalf("DecryptIPPfxTo IPv6 mismatch: got %s", got)
 	}
 
-	if _, err := DecryptIPPfxTo(net.ParseIP("100.115.72.131").To4(), key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+	if _, err := DecryptIPPfxTo(mustParseIPPreserveWidth(t, "100.115.72.131"), key, make([]byte, net.IPv4len-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
 		t.Fatalf("expected short IPv4 buffer error, got %v", err)
 	}
-	if _, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+	if _, err := DecryptIPPfxTo(mustParseIPPreserveWidth(t, "100.115.72.131"), key, make([]byte, net.IPv4len+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected oversized IPv4 buffer error, got %v", err)
+	}
+	if _, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, make([]byte, net.IPv6len-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
 		t.Fatalf("expected short IPv6 buffer error, got %v", err)
+	}
+	if _, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, make([]byte, net.IPv6len+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected oversized IPv6 buffer error, got %v", err)
 	}
 }
 
@@ -668,8 +735,12 @@ func TestIPPfxScratchPadReuseAcrossCalls(t *testing.T) {
 	}
 
 	for _, tc := range encryptCases {
-		buf := make([]byte, MaxIPSize)
-		encrypted, err := EncryptIPPfxTo(net.ParseIP(tc.ip), key, buf, scratch)
+		bufSize := net.IPv6len
+		if netip.MustParseAddr(tc.ip).Is4() {
+			bufSize = net.IPv4len
+		}
+		buf := make([]byte, bufSize)
+		encrypted, err := EncryptIPPfxTo(mustParseIPPreserveWidth(t, tc.ip), key, buf, scratch)
 		if err != nil {
 			t.Fatalf("EncryptIPPfxTo(%s) failed: %v", tc.ip, err)
 		}
@@ -691,8 +762,12 @@ func TestIPPfxScratchPadReuseAcrossCalls(t *testing.T) {
 	}
 
 	for _, tc := range decryptCases {
-		buf := make([]byte, MaxIPSize)
-		decrypted, err := DecryptIPPfxTo(net.ParseIP(tc.ciphertext), key, buf, scratch)
+		bufSize := net.IPv6len
+		if netip.MustParseAddr(tc.ciphertext).Is4() {
+			bufSize = net.IPv4len
+		}
+		buf := make([]byte, bufSize)
+		decrypted, err := DecryptIPPfxTo(mustParseIPPreserveWidth(t, tc.ciphertext), key, buf, scratch)
 		if err != nil {
 			t.Fatalf("DecryptIPPfxTo(%s) failed: %v", tc.ciphertext, err)
 		}
@@ -727,6 +802,9 @@ func TestEncryptIPNonDeterministicXTo(t *testing.T) {
 	if _, err := EncryptIPNonDeterministicXTo(net.ParseIP("192.0.2.1"), key, tweak, make([]byte, NonDeterministicXSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
 		t.Fatalf("expected short-buffer error, got %v", err)
 	}
+	if _, err := EncryptIPNonDeterministicXTo(net.ParseIP("192.0.2.1"), key, tweak, make([]byte, NonDeterministicXSize+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected oversized-buffer error, got %v", err)
+	}
 }
 
 func TestDecryptIPNonDeterministicXTo(t *testing.T) {
@@ -734,7 +812,7 @@ func TestDecryptIPNonDeterministicXTo(t *testing.T) {
 	ciphertext, _ := hex.DecodeString("08e0c289bff23b7cb4ecbe30b70898d7766a533392a69edf1ad0d3ce362ba98a")
 	scratch := NewScratchPad()
 
-	buf := make([]byte, MaxIPSize)
+	buf := make([]byte, net.IPv6len)
 	decrypted, err := DecryptIPNonDeterministicXTo(ciphertext, key, buf, scratch)
 	if err != nil {
 		t.Fatalf("DecryptIPNonDeterministicXTo failed: %v", err)
@@ -748,8 +826,11 @@ func TestDecryptIPNonDeterministicXTo(t *testing.T) {
 		t.Fatalf("DecryptIPNonDeterministicXTo mismatch: got %s", decrypted)
 	}
 
-	if _, err := DecryptIPNonDeterministicXTo(ciphertext, key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+	if _, err := DecryptIPNonDeterministicXTo(ciphertext, key, make([]byte, net.IPv6len-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
 		t.Fatalf("expected short-buffer error, got %v", err)
+	}
+	if _, err := DecryptIPNonDeterministicXTo(ciphertext, key, make([]byte, net.IPv6len+1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected oversized-buffer error, got %v", err)
 	}
 }
 
@@ -810,7 +891,7 @@ func TestIPNonDeterministicXScratchPadReuseAcrossCalls(t *testing.T) {
 	}
 
 	for _, tc := range decryptCases {
-		buf := make([]byte, MaxIPSize)
+		buf := make([]byte, net.IPv6len)
 		decrypted, err := DecryptIPNonDeterministicXTo(tc.ciphertext, tc.key, buf, scratch)
 		if err != nil {
 			t.Fatalf("DecryptIPNonDeterministicXTo failed: %v", err)
@@ -891,7 +972,7 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("DeterministicEncryptTo", func(b *testing.B) {
 		for _, tc := range deterministicCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPSize)
+				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				if _, err := EncryptIPTo(tc.key, tc.ip, buf, scratch); err != nil {
 					b.Fatal(err)
@@ -926,7 +1007,7 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("DeterministicDecryptTo", func(b *testing.B) {
 		for _, tc := range deterministicCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPSize)
+				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				if _, err := DecryptIPTo(tc.key, tc.cipherIP, buf, scratch); err != nil {
 					b.Fatal(err)
@@ -993,7 +1074,7 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("NDDecryptTo", func(b *testing.B) {
 		for _, tc := range ndCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPSize)
+				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
@@ -1057,7 +1138,7 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("NDXDecryptTo", func(b *testing.B) {
 		for _, tc := range ndxCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPSize)
+				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
@@ -1089,7 +1170,7 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("PFXEncryptTo", func(b *testing.B) {
 		for _, tc := range pfxCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPSize)
+				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
@@ -1121,7 +1202,7 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("PFXDecryptTo", func(b *testing.B) {
 		for _, tc := range pfxCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPSize)
+				buf := make([]byte, net.IPv6len)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
@@ -1191,10 +1272,7 @@ func benchmarkCasesFromTestVectors(b *testing.B, variant string) []benchmarkVect
 
 		switch variant {
 		case "ipcrypt-deterministic", "ipcrypt-pfx":
-			tc.cipherIP = net.ParseIP(tv.output)
-			if tc.cipherIP == nil {
-				b.Fatalf("invalid benchmark ciphertext IP in test vector: %s", tv.output)
-			}
+			tc.cipherIP = mustParseIPPreserveWidth(b, tv.output)
 		case "ipcrypt-nd", "ipcrypt-ndx":
 			tc.ciphertext, err = hex.DecodeString(tv.output)
 			if err != nil {

--- a/ipcrypt_test.go
+++ b/ipcrypt_test.go
@@ -40,6 +40,12 @@ var testVectors = []testVector{
 		ip:      "192.0.2.1",
 		output:  "1dbd:c1b9:fff1:7586:7d0b:67b4:e76e:4777",
 	},
+	{
+		variant: "ipcrypt-deterministic",
+		key:     "2b7e151628aed2a6abf7158809cf4f3c",
+		ip:      "2001:db8::1",
+		output:  "10ea:8047:d631:d47d:150d:53dc:6ff3:9302",
+	},
 
 	// ipcrypt-nd test vectors
 	{
@@ -526,6 +532,291 @@ func TestDecryptIPPfxAcceptsFourByteEncryptedIPv4(t *testing.T) {
 	}
 }
 
+func TestEncryptIPNonDeterministicTo(t *testing.T) {
+	key, _ := hex.DecodeString("1032547698badcfeefcdab8967452301")
+	tweak, _ := hex.DecodeString("21bd1834bc088cd2")
+
+	buf := make([]byte, NonDeterministicSize)
+	encrypted, err := EncryptIPNonDeterministicTo("192.0.2.1", key, tweak, buf)
+	if err != nil {
+		t.Fatalf("EncryptIPNonDeterministicTo failed: %v", err)
+	}
+
+	if &encrypted[0] != &buf[0] {
+		t.Fatal("EncryptIPNonDeterministicTo did not reuse caller buffer")
+	}
+
+	if got := hex.EncodeToString(encrypted); got != "21bd1834bc088cd2e5e1fe55f95876e639faae2594a0caad" {
+		t.Fatalf("EncryptIPNonDeterministicTo mismatch: got %s", got)
+	}
+
+	if _, err := EncryptIPNonDeterministicTo("192.0.2.1", key, tweak, make([]byte, NonDeterministicSize-1)); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected short-buffer error, got %v", err)
+	}
+}
+
+func TestDecryptIPNonDeterministicTo(t *testing.T) {
+	key, _ := hex.DecodeString("1032547698badcfeefcdab8967452301")
+	ciphertext, _ := hex.DecodeString("21bd1834bc088cd2e5e1fe55f95876e639faae2594a0caad")
+
+	buf := make([]byte, MaxIPLength)
+	decrypted, err := DecryptIPNonDeterministicTo(ciphertext, key, buf)
+	if err != nil {
+		t.Fatalf("DecryptIPNonDeterministicTo failed: %v", err)
+	}
+
+	if &decrypted[0] != &buf[0] {
+		t.Fatal("DecryptIPNonDeterministicTo did not reuse caller buffer")
+	}
+
+	if !decrypted.Equal(net.ParseIP("192.0.2.1")) {
+		t.Fatalf("DecryptIPNonDeterministicTo mismatch: got %s", decrypted)
+	}
+
+	if _, err := DecryptIPNonDeterministicTo(ciphertext, key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected short-buffer error, got %v", err)
+	}
+}
+
+func TestEncryptIPPfxTo(t *testing.T) {
+	key, _ := hex.DecodeString("0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301")
+
+	ipv4Buf := make([]byte, MaxIPLength)
+	encryptedIPv4, err := EncryptIPPfxTo(net.ParseIP("192.0.2.1"), key, ipv4Buf)
+	if err != nil {
+		t.Fatalf("EncryptIPPfxTo IPv4 failed: %v", err)
+	}
+	if &encryptedIPv4[0] != &ipv4Buf[0] {
+		t.Fatal("EncryptIPPfxTo IPv4 did not reuse caller buffer")
+	}
+	if got := encryptedIPv4.String(); got != "100.115.72.131" {
+		t.Fatalf("EncryptIPPfxTo IPv4 mismatch: got %s", got)
+	}
+
+	ipv6Buf := make([]byte, MaxIPLength)
+	encryptedIPv6, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, ipv6Buf)
+	if err != nil {
+		t.Fatalf("EncryptIPPfxTo IPv6 failed: %v", err)
+	}
+	if &encryptedIPv6[0] != &ipv6Buf[0] {
+		t.Fatal("EncryptIPPfxTo IPv6 did not reuse caller buffer")
+	}
+	if got := encryptedIPv6.String(); got != "c180:5dd4:2587:3524:30ab:fa65:6ab6:f88" {
+		t.Fatalf("EncryptIPPfxTo IPv6 mismatch: got %s", got)
+	}
+
+	if _, err := EncryptIPPfxTo(net.ParseIP("192.0.2.1"), key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected short IPv4 buffer error, got %v", err)
+	}
+	if _, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected short IPv6 buffer error, got %v", err)
+	}
+}
+
+func TestDecryptIPPfxTo(t *testing.T) {
+	key, _ := hex.DecodeString("0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301")
+
+	ipv4Buf := make([]byte, MaxIPLength)
+	decryptedIPv4, err := DecryptIPPfxTo(net.ParseIP("100.115.72.131").To4(), key, ipv4Buf)
+	if err != nil {
+		t.Fatalf("DecryptIPPfxTo IPv4 failed: %v", err)
+	}
+	if &decryptedIPv4[0] != &ipv4Buf[0] {
+		t.Fatal("DecryptIPPfxTo IPv4 did not reuse caller buffer")
+	}
+	if got := decryptedIPv4.String(); got != "192.0.2.1" {
+		t.Fatalf("DecryptIPPfxTo IPv4 mismatch: got %s", got)
+	}
+
+	ipv6Buf := make([]byte, MaxIPLength)
+	decryptedIPv6, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, ipv6Buf)
+	if err != nil {
+		t.Fatalf("DecryptIPPfxTo IPv6 failed: %v", err)
+	}
+	if &decryptedIPv6[0] != &ipv6Buf[0] {
+		t.Fatal("DecryptIPPfxTo IPv6 did not reuse caller buffer")
+	}
+	if got := decryptedIPv6.String(); got != "2001:db8::1" {
+		t.Fatalf("DecryptIPPfxTo IPv6 mismatch: got %s", got)
+	}
+
+	if _, err := DecryptIPPfxTo(net.ParseIP("100.115.72.131").To4(), key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected short IPv4 buffer error, got %v", err)
+	}
+	if _, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected short IPv6 buffer error, got %v", err)
+	}
+}
+
+func TestIPPfxScratchPadReuseAcrossCalls(t *testing.T) {
+	key, _ := hex.DecodeString("0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301")
+	scratch := NewScratchPad()
+
+	encryptCases := []struct {
+		ip       string
+		expected string
+	}{
+		{ip: "192.0.2.1", expected: "100.115.72.131"},
+		{ip: "2001:db8::1", expected: "c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"},
+		{ip: "2001:db8::2", expected: "c180:5dd4:2587:3524:30ab:fa65:6ab6:f8a"},
+		{ip: "0.0.0.0", expected: "151.82.155.134"},
+	}
+
+	for _, tc := range encryptCases {
+		buf := make([]byte, MaxIPLength)
+		encrypted, err := EncryptIPPfxToScratch(net.ParseIP(tc.ip), key, buf, scratch)
+		if err != nil {
+			t.Fatalf("EncryptIPPfxToScratch(%s) failed: %v", tc.ip, err)
+		}
+		if &encrypted[0] != &buf[0] {
+			t.Fatalf("EncryptIPPfxToScratch(%s) did not reuse caller buffer", tc.ip)
+		}
+		if got := encrypted.String(); got != tc.expected {
+			t.Fatalf("EncryptIPPfxToScratch(%s) mismatch: got %s, want %s", tc.ip, got, tc.expected)
+		}
+	}
+
+	decryptCases := []struct {
+		ciphertext string
+		expected   string
+	}{
+		{ciphertext: "100.115.72.131", expected: "192.0.2.1"},
+		{ciphertext: "c180:5dd4:2587:3524:30ab:fa65:6ab6:f88", expected: "2001:db8::1"},
+		{ciphertext: "151.82.155.134", expected: "0.0.0.0"},
+	}
+
+	for _, tc := range decryptCases {
+		buf := make([]byte, MaxIPLength)
+		decrypted, err := DecryptIPPfxToScratch(net.ParseIP(tc.ciphertext), key, buf, scratch)
+		if err != nil {
+			t.Fatalf("DecryptIPPfxToScratch(%s) failed: %v", tc.ciphertext, err)
+		}
+		if &decrypted[0] != &buf[0] {
+			t.Fatalf("DecryptIPPfxToScratch(%s) did not reuse caller buffer", tc.ciphertext)
+		}
+		if got := decrypted.String(); got != tc.expected {
+			t.Fatalf("DecryptIPPfxToScratch(%s) mismatch: got %s, want %s", tc.ciphertext, got, tc.expected)
+		}
+	}
+}
+
+func TestEncryptIPNonDeterministicXTo(t *testing.T) {
+	key, _ := hex.DecodeString("1032547698badcfeefcdab89674523010123456789abcdeffedcba9876543210")
+	tweak, _ := hex.DecodeString("08e0c289bff23b7cb4ecbe30b70898d7")
+
+	buf := make([]byte, NonDeterministicXSize)
+	encrypted, err := EncryptIPNonDeterministicXTo("192.0.2.1", key, tweak, buf)
+	if err != nil {
+		t.Fatalf("EncryptIPNonDeterministicXTo failed: %v", err)
+	}
+
+	if &encrypted[0] != &buf[0] {
+		t.Fatal("EncryptIPNonDeterministicXTo did not reuse caller buffer")
+	}
+
+	if got := hex.EncodeToString(encrypted); got != "08e0c289bff23b7cb4ecbe30b70898d7766a533392a69edf1ad0d3ce362ba98a" {
+		t.Fatalf("EncryptIPNonDeterministicXTo mismatch: got %s", got)
+	}
+
+	if _, err := EncryptIPNonDeterministicXTo("192.0.2.1", key, tweak, make([]byte, NonDeterministicXSize-1)); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+		t.Fatalf("expected short-buffer error, got %v", err)
+	}
+}
+
+func TestDecryptIPNonDeterministicXTo(t *testing.T) {
+	key, _ := hex.DecodeString("1032547698badcfeefcdab89674523010123456789abcdeffedcba9876543210")
+	ciphertext, _ := hex.DecodeString("08e0c289bff23b7cb4ecbe30b70898d7766a533392a69edf1ad0d3ce362ba98a")
+
+	buf := make([]byte, MaxIPLength)
+	decrypted, err := DecryptIPNonDeterministicXTo(ciphertext, key, buf)
+	if err != nil {
+		t.Fatalf("DecryptIPNonDeterministicXTo failed: %v", err)
+	}
+
+	if &decrypted[0] != &buf[0] {
+		t.Fatal("DecryptIPNonDeterministicXTo did not reuse caller buffer")
+	}
+
+	if !decrypted.Equal(net.ParseIP("192.0.2.1")) {
+		t.Fatalf("DecryptIPNonDeterministicXTo mismatch: got %s", decrypted)
+	}
+
+	if _, err := DecryptIPNonDeterministicXTo(ciphertext, key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+		t.Fatalf("expected short-buffer error, got %v", err)
+	}
+}
+
+func TestIPNonDeterministicXScratchPadReuseAcrossCalls(t *testing.T) {
+	key1, _ := hex.DecodeString("1032547698badcfeefcdab89674523010123456789abcdeffedcba9876543210")
+	key2, _ := hex.DecodeString("2b7e151628aed2a6abf7158809cf4f3c3c4fcf098815f7aba6d2ae2816157e2b")
+	tweak1, _ := hex.DecodeString("08e0c289bff23b7cb4ecbe30b70898d7")
+	tweak2, _ := hex.DecodeString("21bd1834bc088cd2b4ecbe30b70898d7")
+	scratch := NewScratchPad()
+
+	encryptCases := []struct {
+		ip       string
+		key      []byte
+		tweak    []byte
+		expected string
+	}{
+		{
+			ip:       "192.0.2.1",
+			key:      key1,
+			tweak:    tweak1,
+			expected: "08e0c289bff23b7cb4ecbe30b70898d7766a533392a69edf1ad0d3ce362ba98a",
+		},
+		{
+			ip:       "2001:db8::1",
+			key:      key2,
+			tweak:    tweak2,
+			expected: "21bd1834bc088cd2b4ecbe30b70898d76089c7e05ae30c2d10ca149870a263e4",
+		},
+	}
+
+	ciphertexts := make([][]byte, 0, len(encryptCases))
+	for _, tc := range encryptCases {
+		buf := make([]byte, NonDeterministicXSize)
+		encrypted, err := EncryptIPNonDeterministicXToScratch(tc.ip, tc.key, tc.tweak, buf, scratch)
+		if err != nil {
+			t.Fatalf("EncryptIPNonDeterministicXToScratch(%s) failed: %v", tc.ip, err)
+		}
+		if &encrypted[0] != &buf[0] {
+			t.Fatalf("EncryptIPNonDeterministicXToScratch(%s) did not reuse caller buffer", tc.ip)
+		}
+		if got := hex.EncodeToString(encrypted); got != tc.expected {
+			t.Fatalf("EncryptIPNonDeterministicXToScratch(%s) mismatch: got %s, want %s", tc.ip, got, tc.expected)
+		}
+
+		stableCopy := make([]byte, len(encrypted))
+		copy(stableCopy, encrypted)
+		ciphertexts = append(ciphertexts, stableCopy)
+	}
+
+	decryptCases := []struct {
+		ciphertext []byte
+		key        []byte
+		expected   string
+	}{
+		{ciphertext: ciphertexts[0], key: key1, expected: "192.0.2.1"},
+		{ciphertext: ciphertexts[1], key: key2, expected: "2001:db8::1"},
+		{ciphertext: ciphertexts[0], key: key1, expected: "192.0.2.1"},
+	}
+
+	for _, tc := range decryptCases {
+		buf := make([]byte, MaxIPLength)
+		decrypted, err := DecryptIPNonDeterministicXToScratch(tc.ciphertext, tc.key, buf, scratch)
+		if err != nil {
+			t.Fatalf("DecryptIPNonDeterministicXToScratch failed: %v", err)
+		}
+		if &decrypted[0] != &buf[0] {
+			t.Fatal("DecryptIPNonDeterministicXToScratch did not reuse caller buffer")
+		}
+		if got := decrypted.String(); got != tc.expected {
+			t.Fatalf("DecryptIPNonDeterministicXToScratch mismatch: got %s, want %s", got, tc.expected)
+		}
+	}
+}
+
 // TestInvalidInputs tests error handling for invalid inputs.
 func TestInvalidInputs(t *testing.T) {
 	// Test invalid key length
@@ -551,4 +842,423 @@ func TestInvalidInputs(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "invalid ciphertext length") {
 		t.Errorf("Expected invalid ciphertext length error, got %v", err)
 	}
+}
+
+var (
+	benchmarkIPSink     net.IP
+	benchmarkBytesSink  []byte
+	benchmarkStringSink string
+)
+
+type benchmarkVectorCase struct {
+	name       string
+	key        []byte
+	tweak      []byte
+	ip         net.IP
+	ipString   string
+	cipherIP   net.IP
+	ciphertext []byte
+}
+
+func BenchmarkAllocations(b *testing.B) {
+	deterministicCases := benchmarkCasesFromTestVectors(b, "ipcrypt-deterministic")
+	ndCases := benchmarkCasesFromTestVectors(b, "ipcrypt-nd")
+	ndxCases := benchmarkCasesFromTestVectors(b, "ipcrypt-ndx")
+	pfxCases := benchmarkCasesFromTestVectors(b, "ipcrypt-pfx")
+
+	b.Run("DeterministicEncrypt", func(b *testing.B) {
+		for _, tc := range deterministicCases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					ip, err := EncryptIP(tc.key, tc.ip)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = ip
+				}
+			})
+		}
+	})
+
+	b.Run("DeterministicEncryptTo", func(b *testing.B) {
+		for _, tc := range deterministicCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				b.ReportAllocs()
+				for b.Loop() {
+					ip, err := EncryptIPTo(tc.key, tc.ip, buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = ip
+				}
+			})
+		}
+	})
+
+	b.Run("DeterministicDecrypt", func(b *testing.B) {
+		for _, tc := range deterministicCases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					ip, err := DecryptIP(tc.key, tc.cipherIP)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = ip
+				}
+			})
+		}
+	})
+
+	b.Run("DeterministicDecryptTo", func(b *testing.B) {
+		for _, tc := range deterministicCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				b.ReportAllocs()
+				for b.Loop() {
+					ip, err := DecryptIPTo(tc.key, tc.cipherIP, buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = ip
+				}
+			})
+		}
+	})
+
+	b.Run("NDEncrypt", func(b *testing.B) {
+		for _, tc := range ndCases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := EncryptIPNonDeterministic(tc.ipString, tc.key, tc.tweak)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkBytesSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDEncryptTo", func(b *testing.B) {
+		for _, tc := range ndCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, NonDeterministicSize)
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := EncryptIPNonDeterministicTo(tc.ipString, tc.key, tc.tweak, buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkBytesSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDDecrypt", func(b *testing.B) {
+		for _, tc := range ndCases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := DecryptIPNonDeterministic(tc.ciphertext, tc.key)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkStringSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDDecryptTo", func(b *testing.B) {
+		for _, tc := range ndCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := DecryptIPNonDeterministicTo(tc.ciphertext, tc.key, buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDXEncrypt", func(b *testing.B) {
+		for _, tc := range ndxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := EncryptIPNonDeterministicX(tc.ipString, tc.key, tc.tweak)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkBytesSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDXEncryptTo", func(b *testing.B) {
+		for _, tc := range ndxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, NonDeterministicXSize)
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := EncryptIPNonDeterministicXTo(tc.ipString, tc.key, tc.tweak, buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkBytesSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDXEncryptToScratch", func(b *testing.B) {
+		for _, tc := range ndxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, NonDeterministicXSize)
+				scratch := NewScratchPad()
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := EncryptIPNonDeterministicXToScratch(tc.ipString, tc.key, tc.tweak, buf, scratch)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkBytesSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDXDecrypt", func(b *testing.B) {
+		for _, tc := range ndxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := DecryptIPNonDeterministicX(tc.ciphertext, tc.key)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkStringSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDXDecryptTo", func(b *testing.B) {
+		for _, tc := range ndxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := DecryptIPNonDeterministicXTo(tc.ciphertext, tc.key, buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("NDXDecryptToScratch", func(b *testing.B) {
+		for _, tc := range ndxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				scratch := NewScratchPad()
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := DecryptIPNonDeterministicXToScratch(tc.ciphertext, tc.key, buf, scratch)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("PFXEncrypt", func(b *testing.B) {
+		for _, tc := range pfxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := EncryptIPPfx(tc.ip, tc.key)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("PFXEncryptTo", func(b *testing.B) {
+		for _, tc := range pfxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := EncryptIPPfxTo(tc.ip, tc.key, buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("PFXEncryptToScratch", func(b *testing.B) {
+		for _, tc := range pfxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				scratch := NewScratchPad()
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := EncryptIPPfxToScratch(tc.ip, tc.key, buf, scratch)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("PFXDecrypt", func(b *testing.B) {
+		for _, tc := range pfxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := DecryptIPPfx(tc.cipherIP, tc.key)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("PFXDecryptTo", func(b *testing.B) {
+		for _, tc := range pfxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := DecryptIPPfxTo(tc.cipherIP, tc.key, buf)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+
+	b.Run("PFXDecryptToScratch", func(b *testing.B) {
+		for _, tc := range pfxCases {
+			b.Run(tc.name, func(b *testing.B) {
+				buf := make([]byte, MaxIPLength)
+				scratch := NewScratchPad()
+				b.ReportAllocs()
+				for b.Loop() {
+					out, err := DecryptIPPfxToScratch(tc.cipherIP, tc.key, buf, scratch)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkIPSink = out
+				}
+			})
+		}
+	})
+}
+
+func benchmarkCasesFromTestVectors(b *testing.B, variant string) []benchmarkVectorCase {
+	b.Helper()
+
+	var cases []benchmarkVectorCase
+	haveIPv4 := false
+	haveIPv6 := false
+
+	for _, tv := range testVectors {
+		if tv.variant != variant {
+			continue
+		}
+
+		ip := net.ParseIP(tv.ip)
+		if ip == nil {
+			b.Fatalf("invalid benchmark IP in test vector: %s", tv.ip)
+		}
+
+		isIPv4 := ip.To4() != nil
+		if isIPv4 && haveIPv4 {
+			continue
+		}
+		if !isIPv4 && haveIPv6 {
+			continue
+		}
+
+		key, err := hex.DecodeString(tv.key)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		tc := benchmarkVectorCase{
+			name:     ipFamilyName(ip),
+			key:      key,
+			ip:       ip,
+			ipString: tv.ip,
+		}
+
+		if tv.tweak != "" {
+			tc.tweak, err = hex.DecodeString(tv.tweak)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		switch variant {
+		case "ipcrypt-deterministic", "ipcrypt-pfx":
+			tc.cipherIP = net.ParseIP(tv.output)
+			if tc.cipherIP == nil {
+				b.Fatalf("invalid benchmark ciphertext IP in test vector: %s", tv.output)
+			}
+		case "ipcrypt-nd", "ipcrypt-ndx":
+			tc.ciphertext, err = hex.DecodeString(tv.output)
+			if err != nil {
+				b.Fatal(err)
+			}
+		default:
+			b.Fatalf("unsupported benchmark variant: %s", variant)
+		}
+
+		cases = append(cases, tc)
+		if isIPv4 {
+			haveIPv4 = true
+		} else {
+			haveIPv6 = true
+		}
+	}
+
+	if len(cases) == 0 {
+		b.Fatalf("no benchmark cases found for variant %s", variant)
+	}
+	return cases
+}
+
+func ipFamilyName(ip net.IP) string {
+	if ip.To4() != nil {
+		return "IPv4"
+	}
+	return "IPv6"
 }

--- a/ipcrypt_test.go
+++ b/ipcrypt_test.go
@@ -535,9 +535,10 @@ func TestDecryptIPPfxAcceptsFourByteEncryptedIPv4(t *testing.T) {
 func TestEncryptIPNonDeterministicTo(t *testing.T) {
 	key, _ := hex.DecodeString("1032547698badcfeefcdab8967452301")
 	tweak, _ := hex.DecodeString("21bd1834bc088cd2")
+	scratch := NewScratchPad()
 
 	buf := make([]byte, NonDeterministicSize)
-	encrypted, err := EncryptIPNonDeterministicTo("192.0.2.1", key, tweak, buf)
+	encrypted, err := EncryptIPNonDeterministicTo(net.ParseIP("192.0.2.1"), key, tweak, buf, scratch)
 	if err != nil {
 		t.Fatalf("EncryptIPNonDeterministicTo failed: %v", err)
 	}
@@ -550,7 +551,7 @@ func TestEncryptIPNonDeterministicTo(t *testing.T) {
 		t.Fatalf("EncryptIPNonDeterministicTo mismatch: got %s", got)
 	}
 
-	if _, err := EncryptIPNonDeterministicTo("192.0.2.1", key, tweak, make([]byte, NonDeterministicSize-1)); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+	if _, err := EncryptIPNonDeterministicTo(net.ParseIP("192.0.2.1"), key, tweak, make([]byte, NonDeterministicSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
 		t.Fatalf("expected short-buffer error, got %v", err)
 	}
 }
@@ -558,9 +559,10 @@ func TestEncryptIPNonDeterministicTo(t *testing.T) {
 func TestDecryptIPNonDeterministicTo(t *testing.T) {
 	key, _ := hex.DecodeString("1032547698badcfeefcdab8967452301")
 	ciphertext, _ := hex.DecodeString("21bd1834bc088cd2e5e1fe55f95876e639faae2594a0caad")
+	scratch := NewScratchPad()
 
-	buf := make([]byte, MaxIPLength)
-	decrypted, err := DecryptIPNonDeterministicTo(ciphertext, key, buf)
+	buf := make([]byte, MaxIPSize)
+	decrypted, err := DecryptIPNonDeterministicTo(ciphertext, key, buf, scratch)
 	if err != nil {
 		t.Fatalf("DecryptIPNonDeterministicTo failed: %v", err)
 	}
@@ -573,16 +575,17 @@ func TestDecryptIPNonDeterministicTo(t *testing.T) {
 		t.Fatalf("DecryptIPNonDeterministicTo mismatch: got %s", decrypted)
 	}
 
-	if _, err := DecryptIPNonDeterministicTo(ciphertext, key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+	if _, err := DecryptIPNonDeterministicTo(ciphertext, key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
 		t.Fatalf("expected short-buffer error, got %v", err)
 	}
 }
 
 func TestEncryptIPPfxTo(t *testing.T) {
 	key, _ := hex.DecodeString("0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301")
+	scratch := NewScratchPad()
 
-	ipv4Buf := make([]byte, MaxIPLength)
-	encryptedIPv4, err := EncryptIPPfxTo(net.ParseIP("192.0.2.1"), key, ipv4Buf)
+	ipv4Buf := make([]byte, MaxIPSize)
+	encryptedIPv4, err := EncryptIPPfxTo(net.ParseIP("192.0.2.1"), key, ipv4Buf, scratch)
 	if err != nil {
 		t.Fatalf("EncryptIPPfxTo IPv4 failed: %v", err)
 	}
@@ -593,8 +596,8 @@ func TestEncryptIPPfxTo(t *testing.T) {
 		t.Fatalf("EncryptIPPfxTo IPv4 mismatch: got %s", got)
 	}
 
-	ipv6Buf := make([]byte, MaxIPLength)
-	encryptedIPv6, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, ipv6Buf)
+	ipv6Buf := make([]byte, MaxIPSize)
+	encryptedIPv6, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, ipv6Buf, scratch)
 	if err != nil {
 		t.Fatalf("EncryptIPPfxTo IPv6 failed: %v", err)
 	}
@@ -605,19 +608,20 @@ func TestEncryptIPPfxTo(t *testing.T) {
 		t.Fatalf("EncryptIPPfxTo IPv6 mismatch: got %s", got)
 	}
 
-	if _, err := EncryptIPPfxTo(net.ParseIP("192.0.2.1"), key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+	if _, err := EncryptIPPfxTo(net.ParseIP("192.0.2.1"), key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
 		t.Fatalf("expected short IPv4 buffer error, got %v", err)
 	}
-	if _, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+	if _, err := EncryptIPPfxTo(net.ParseIP("2001:db8::1"), key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
 		t.Fatalf("expected short IPv6 buffer error, got %v", err)
 	}
 }
 
 func TestDecryptIPPfxTo(t *testing.T) {
 	key, _ := hex.DecodeString("0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301")
+	scratch := NewScratchPad()
 
-	ipv4Buf := make([]byte, MaxIPLength)
-	decryptedIPv4, err := DecryptIPPfxTo(net.ParseIP("100.115.72.131").To4(), key, ipv4Buf)
+	ipv4Buf := make([]byte, MaxIPSize)
+	decryptedIPv4, err := DecryptIPPfxTo(net.ParseIP("100.115.72.131").To4(), key, ipv4Buf, scratch)
 	if err != nil {
 		t.Fatalf("DecryptIPPfxTo IPv4 failed: %v", err)
 	}
@@ -628,8 +632,8 @@ func TestDecryptIPPfxTo(t *testing.T) {
 		t.Fatalf("DecryptIPPfxTo IPv4 mismatch: got %s", got)
 	}
 
-	ipv6Buf := make([]byte, MaxIPLength)
-	decryptedIPv6, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, ipv6Buf)
+	ipv6Buf := make([]byte, MaxIPSize)
+	decryptedIPv6, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, ipv6Buf, scratch)
 	if err != nil {
 		t.Fatalf("DecryptIPPfxTo IPv6 failed: %v", err)
 	}
@@ -640,10 +644,10 @@ func TestDecryptIPPfxTo(t *testing.T) {
 		t.Fatalf("DecryptIPPfxTo IPv6 mismatch: got %s", got)
 	}
 
-	if _, err := DecryptIPPfxTo(net.ParseIP("100.115.72.131").To4(), key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+	if _, err := DecryptIPPfxTo(net.ParseIP("100.115.72.131").To4(), key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
 		t.Fatalf("expected short IPv4 buffer error, got %v", err)
 	}
-	if _, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+	if _, err := DecryptIPPfxTo(net.ParseIP("c180:5dd4:2587:3524:30ab:fa65:6ab6:f88"), key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
 		t.Fatalf("expected short IPv6 buffer error, got %v", err)
 	}
 }
@@ -663,16 +667,16 @@ func TestIPPfxScratchPadReuseAcrossCalls(t *testing.T) {
 	}
 
 	for _, tc := range encryptCases {
-		buf := make([]byte, MaxIPLength)
-		encrypted, err := EncryptIPPfxToScratch(net.ParseIP(tc.ip), key, buf, scratch)
+		buf := make([]byte, MaxIPSize)
+		encrypted, err := EncryptIPPfxTo(net.ParseIP(tc.ip), key, buf, scratch)
 		if err != nil {
-			t.Fatalf("EncryptIPPfxToScratch(%s) failed: %v", tc.ip, err)
+			t.Fatalf("EncryptIPPfxTo(%s) failed: %v", tc.ip, err)
 		}
 		if &encrypted[0] != &buf[0] {
-			t.Fatalf("EncryptIPPfxToScratch(%s) did not reuse caller buffer", tc.ip)
+			t.Fatalf("EncryptIPPfxTo(%s) did not reuse caller buffer", tc.ip)
 		}
 		if got := encrypted.String(); got != tc.expected {
-			t.Fatalf("EncryptIPPfxToScratch(%s) mismatch: got %s, want %s", tc.ip, got, tc.expected)
+			t.Fatalf("EncryptIPPfxTo(%s) mismatch: got %s, want %s", tc.ip, got, tc.expected)
 		}
 	}
 
@@ -686,16 +690,16 @@ func TestIPPfxScratchPadReuseAcrossCalls(t *testing.T) {
 	}
 
 	for _, tc := range decryptCases {
-		buf := make([]byte, MaxIPLength)
-		decrypted, err := DecryptIPPfxToScratch(net.ParseIP(tc.ciphertext), key, buf, scratch)
+		buf := make([]byte, MaxIPSize)
+		decrypted, err := DecryptIPPfxTo(net.ParseIP(tc.ciphertext), key, buf, scratch)
 		if err != nil {
-			t.Fatalf("DecryptIPPfxToScratch(%s) failed: %v", tc.ciphertext, err)
+			t.Fatalf("DecryptIPPfxTo(%s) failed: %v", tc.ciphertext, err)
 		}
 		if &decrypted[0] != &buf[0] {
-			t.Fatalf("DecryptIPPfxToScratch(%s) did not reuse caller buffer", tc.ciphertext)
+			t.Fatalf("DecryptIPPfxTo(%s) did not reuse caller buffer", tc.ciphertext)
 		}
 		if got := decrypted.String(); got != tc.expected {
-			t.Fatalf("DecryptIPPfxToScratch(%s) mismatch: got %s, want %s", tc.ciphertext, got, tc.expected)
+			t.Fatalf("DecryptIPPfxTo(%s) mismatch: got %s, want %s", tc.ciphertext, got, tc.expected)
 		}
 	}
 }
@@ -703,9 +707,10 @@ func TestIPPfxScratchPadReuseAcrossCalls(t *testing.T) {
 func TestEncryptIPNonDeterministicXTo(t *testing.T) {
 	key, _ := hex.DecodeString("1032547698badcfeefcdab89674523010123456789abcdeffedcba9876543210")
 	tweak, _ := hex.DecodeString("08e0c289bff23b7cb4ecbe30b70898d7")
+	scratch := NewScratchPad()
 
 	buf := make([]byte, NonDeterministicXSize)
-	encrypted, err := EncryptIPNonDeterministicXTo("192.0.2.1", key, tweak, buf)
+	encrypted, err := EncryptIPNonDeterministicXTo(net.ParseIP("192.0.2.1"), key, tweak, buf, scratch)
 	if err != nil {
 		t.Fatalf("EncryptIPNonDeterministicXTo failed: %v", err)
 	}
@@ -718,7 +723,7 @@ func TestEncryptIPNonDeterministicXTo(t *testing.T) {
 		t.Fatalf("EncryptIPNonDeterministicXTo mismatch: got %s", got)
 	}
 
-	if _, err := EncryptIPNonDeterministicXTo("192.0.2.1", key, tweak, make([]byte, NonDeterministicXSize-1)); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
+	if _, err := EncryptIPNonDeterministicXTo(net.ParseIP("192.0.2.1"), key, tweak, make([]byte, NonDeterministicXSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid encrypted parameter") {
 		t.Fatalf("expected short-buffer error, got %v", err)
 	}
 }
@@ -726,9 +731,10 @@ func TestEncryptIPNonDeterministicXTo(t *testing.T) {
 func TestDecryptIPNonDeterministicXTo(t *testing.T) {
 	key, _ := hex.DecodeString("1032547698badcfeefcdab89674523010123456789abcdeffedcba9876543210")
 	ciphertext, _ := hex.DecodeString("08e0c289bff23b7cb4ecbe30b70898d7766a533392a69edf1ad0d3ce362ba98a")
+	scratch := NewScratchPad()
 
-	buf := make([]byte, MaxIPLength)
-	decrypted, err := DecryptIPNonDeterministicXTo(ciphertext, key, buf)
+	buf := make([]byte, MaxIPSize)
+	decrypted, err := DecryptIPNonDeterministicXTo(ciphertext, key, buf, scratch)
 	if err != nil {
 		t.Fatalf("DecryptIPNonDeterministicXTo failed: %v", err)
 	}
@@ -741,7 +747,7 @@ func TestDecryptIPNonDeterministicXTo(t *testing.T) {
 		t.Fatalf("DecryptIPNonDeterministicXTo mismatch: got %s", decrypted)
 	}
 
-	if _, err := DecryptIPNonDeterministicXTo(ciphertext, key, make([]byte, MaxIPLength-1)); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
+	if _, err := DecryptIPNonDeterministicXTo(ciphertext, key, make([]byte, MaxIPSize-1), scratch); err == nil || !strings.Contains(err.Error(), "invalid decrypted parameter") {
 		t.Fatalf("expected short-buffer error, got %v", err)
 	}
 }
@@ -776,15 +782,15 @@ func TestIPNonDeterministicXScratchPadReuseAcrossCalls(t *testing.T) {
 	ciphertexts := make([][]byte, 0, len(encryptCases))
 	for _, tc := range encryptCases {
 		buf := make([]byte, NonDeterministicXSize)
-		encrypted, err := EncryptIPNonDeterministicXToScratch(tc.ip, tc.key, tc.tweak, buf, scratch)
+		encrypted, err := EncryptIPNonDeterministicXTo(net.ParseIP(tc.ip), tc.key, tc.tweak, buf, scratch)
 		if err != nil {
-			t.Fatalf("EncryptIPNonDeterministicXToScratch(%s) failed: %v", tc.ip, err)
+			t.Fatalf("EncryptIPNonDeterministicXTo(%s) failed: %v", tc.ip, err)
 		}
 		if &encrypted[0] != &buf[0] {
-			t.Fatalf("EncryptIPNonDeterministicXToScratch(%s) did not reuse caller buffer", tc.ip)
+			t.Fatalf("EncryptIPNonDeterministicXTo(%s) did not reuse caller buffer", tc.ip)
 		}
 		if got := hex.EncodeToString(encrypted); got != tc.expected {
-			t.Fatalf("EncryptIPNonDeterministicXToScratch(%s) mismatch: got %s, want %s", tc.ip, got, tc.expected)
+			t.Fatalf("EncryptIPNonDeterministicXTo(%s) mismatch: got %s, want %s", tc.ip, got, tc.expected)
 		}
 
 		stableCopy := make([]byte, len(encrypted))
@@ -803,16 +809,16 @@ func TestIPNonDeterministicXScratchPadReuseAcrossCalls(t *testing.T) {
 	}
 
 	for _, tc := range decryptCases {
-		buf := make([]byte, MaxIPLength)
-		decrypted, err := DecryptIPNonDeterministicXToScratch(tc.ciphertext, tc.key, buf, scratch)
+		buf := make([]byte, MaxIPSize)
+		decrypted, err := DecryptIPNonDeterministicXTo(tc.ciphertext, tc.key, buf, scratch)
 		if err != nil {
-			t.Fatalf("DecryptIPNonDeterministicXToScratch failed: %v", err)
+			t.Fatalf("DecryptIPNonDeterministicXTo failed: %v", err)
 		}
 		if &decrypted[0] != &buf[0] {
-			t.Fatal("DecryptIPNonDeterministicXToScratch did not reuse caller buffer")
+			t.Fatal("DecryptIPNonDeterministicXTo did not reuse caller buffer")
 		}
 		if got := decrypted.String(); got != tc.expected {
-			t.Fatalf("DecryptIPNonDeterministicXToScratch mismatch: got %s, want %s", got, tc.expected)
+			t.Fatalf("DecryptIPNonDeterministicXTo mismatch: got %s, want %s", got, tc.expected)
 		}
 	}
 }
@@ -884,10 +890,14 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("DeterministicEncryptTo", func(b *testing.B) {
 		for _, tc := range deterministicCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
+				buf := make([]byte, MaxIPSize)
+				scratch := NewScratchPad()
+				if _, err := EncryptIPTo(tc.key, tc.ip, buf, scratch); err != nil {
+					b.Fatal(err)
+				}
 				b.ReportAllocs()
 				for b.Loop() {
-					ip, err := EncryptIPTo(tc.key, tc.ip, buf)
+					ip, err := EncryptIPTo(tc.key, tc.ip, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -915,10 +925,14 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("DeterministicDecryptTo", func(b *testing.B) {
 		for _, tc := range deterministicCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
+				buf := make([]byte, MaxIPSize)
+				scratch := NewScratchPad()
+				if _, err := DecryptIPTo(tc.key, tc.cipherIP, buf, scratch); err != nil {
+					b.Fatal(err)
+				}
 				b.ReportAllocs()
 				for b.Loop() {
-					ip, err := DecryptIPTo(tc.key, tc.cipherIP, buf)
+					ip, err := DecryptIPTo(tc.key, tc.cipherIP, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -947,9 +961,10 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range ndCases {
 			b.Run(tc.name, func(b *testing.B) {
 				buf := make([]byte, NonDeterministicSize)
+				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
-					out, err := EncryptIPNonDeterministicTo(tc.ipString, tc.key, tc.tweak, buf)
+					out, err := EncryptIPNonDeterministicTo(tc.ip, tc.key, tc.tweak, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -977,10 +992,11 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("NDDecryptTo", func(b *testing.B) {
 		for _, tc := range ndCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
+				buf := make([]byte, MaxIPSize)
+				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
-					out, err := DecryptIPNonDeterministicTo(tc.ciphertext, tc.key, buf)
+					out, err := DecryptIPNonDeterministicTo(tc.ciphertext, tc.key, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -1009,26 +1025,10 @@ func BenchmarkAllocations(b *testing.B) {
 		for _, tc := range ndxCases {
 			b.Run(tc.name, func(b *testing.B) {
 				buf := make([]byte, NonDeterministicXSize)
-				b.ReportAllocs()
-				for b.Loop() {
-					out, err := EncryptIPNonDeterministicXTo(tc.ipString, tc.key, tc.tweak, buf)
-					if err != nil {
-						b.Fatal(err)
-					}
-					benchmarkBytesSink = out
-				}
-			})
-		}
-	})
-
-	b.Run("NDXEncryptToScratch", func(b *testing.B) {
-		for _, tc := range ndxCases {
-			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, NonDeterministicXSize)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
-					out, err := EncryptIPNonDeterministicXToScratch(tc.ipString, tc.key, tc.tweak, buf, scratch)
+					out, err := EncryptIPNonDeterministicXTo(tc.ip, tc.key, tc.tweak, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -1056,27 +1056,11 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("NDXDecryptTo", func(b *testing.B) {
 		for _, tc := range ndxCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
-				b.ReportAllocs()
-				for b.Loop() {
-					out, err := DecryptIPNonDeterministicXTo(tc.ciphertext, tc.key, buf)
-					if err != nil {
-						b.Fatal(err)
-					}
-					benchmarkIPSink = out
-				}
-			})
-		}
-	})
-
-	b.Run("NDXDecryptToScratch", func(b *testing.B) {
-		for _, tc := range ndxCases {
-			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
+				buf := make([]byte, MaxIPSize)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
-					out, err := DecryptIPNonDeterministicXToScratch(tc.ciphertext, tc.key, buf, scratch)
+					out, err := DecryptIPNonDeterministicXTo(tc.ciphertext, tc.key, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -1104,27 +1088,11 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("PFXEncryptTo", func(b *testing.B) {
 		for _, tc := range pfxCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
-				b.ReportAllocs()
-				for b.Loop() {
-					out, err := EncryptIPPfxTo(tc.ip, tc.key, buf)
-					if err != nil {
-						b.Fatal(err)
-					}
-					benchmarkIPSink = out
-				}
-			})
-		}
-	})
-
-	b.Run("PFXEncryptToScratch", func(b *testing.B) {
-		for _, tc := range pfxCases {
-			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
+				buf := make([]byte, MaxIPSize)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
-					out, err := EncryptIPPfxToScratch(tc.ip, tc.key, buf, scratch)
+					out, err := EncryptIPPfxTo(tc.ip, tc.key, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -1152,27 +1120,11 @@ func BenchmarkAllocations(b *testing.B) {
 	b.Run("PFXDecryptTo", func(b *testing.B) {
 		for _, tc := range pfxCases {
 			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
-				b.ReportAllocs()
-				for b.Loop() {
-					out, err := DecryptIPPfxTo(tc.cipherIP, tc.key, buf)
-					if err != nil {
-						b.Fatal(err)
-					}
-					benchmarkIPSink = out
-				}
-			})
-		}
-	})
-
-	b.Run("PFXDecryptToScratch", func(b *testing.B) {
-		for _, tc := range pfxCases {
-			b.Run(tc.name, func(b *testing.B) {
-				buf := make([]byte, MaxIPLength)
+				buf := make([]byte, MaxIPSize)
 				scratch := NewScratchPad()
 				b.ReportAllocs()
 				for b.Loop() {
-					out, err := DecryptIPPfxToScratch(tc.cipherIP, tc.key, buf, scratch)
+					out, err := DecryptIPPfxTo(tc.cipherIP, tc.key, buf, scratch)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/kiasu-bc.go
+++ b/kiasu-bc.go
@@ -164,43 +164,48 @@ func expandKey(key []byte) [][]byte {
 		panic("key must be 16 bytes")
 	}
 
-	// Pre-allocate all memory at once
 	roundKeys := make([][]byte, 11)
 	allKeys := make([]byte, 11*16)
 	for i := range roundKeys {
 		roundKeys[i] = allKeys[i*16 : (i+1)*16]
 	}
+	var roundKeysArray [11][16]byte
+	expandKeyTo(key, &roundKeysArray)
+	for i := range roundKeys {
+		copy(roundKeys[i], roundKeysArray[i][:])
+	}
 
-	// Copy initial key
-	copy(roundKeys[0], key)
+	return roundKeys
+}
 
-	// Single temporary buffer for all rounds
-	temp := make([]byte, 4)
+func expandKeyTo(key []byte, roundKeys *[11][16]byte) {
+	if len(key) != 16 {
+		panic("key must be 16 bytes")
+	}
 
+	copy(roundKeys[0][:], key)
+
+	var temp [4]byte
 	for i := 1; i < 11; i++ {
-		prevKey := roundKeys[i-1]
-		currKey := roundKeys[i]
+		prevKey := roundKeys[i-1][:]
+		currKey := roundKeys[i][:]
 
-		// First word
-		// RotWord
 		temp[0] = prevKey[13]
 		temp[1] = prevKey[14]
 		temp[2] = prevKey[15]
 		temp[3] = prevKey[12]
-		// SubWord
+
 		temp[0] = sbox[temp[0]]
 		temp[1] = sbox[temp[1]]
 		temp[2] = sbox[temp[2]]
 		temp[3] = sbox[temp[3]]
-		// XOR with Rcon
 		temp[0] ^= rcon[i-1]
-		// XOR with previous key
+
 		currKey[0] = prevKey[0] ^ temp[0]
 		currKey[1] = prevKey[1] ^ temp[1]
 		currKey[2] = prevKey[2] ^ temp[2]
 		currKey[3] = prevKey[3] ^ temp[3]
 
-		// Remaining words
 		currKey[4] = currKey[0] ^ prevKey[4]
 		currKey[5] = currKey[1] ^ prevKey[5]
 		currKey[6] = currKey[2] ^ prevKey[6]
@@ -216,8 +221,6 @@ func expandKey(key []byte) [][]byte {
 		currKey[14] = currKey[10] ^ prevKey[14]
 		currKey[15] = currKey[11] ^ prevKey[15]
 	}
-
-	return roundKeys
 }
 
 // padTweak pads an 8-byte tweak to 16 bytes according to KIASU-BC specification.
@@ -227,11 +230,110 @@ func padTweak(tweak []byte) []byte {
 		panic("tweak must be 8 bytes")
 	}
 	padded := make([]byte, 16)
+	padTweakTo(tweak, padded)
+	return padded
+}
+
+func padTweakTo(tweak, padded []byte) {
+	if len(tweak) != 8 {
+		panic("tweak must be 8 bytes")
+	}
+	if len(padded) != 16 {
+		panic("padded tweak must be 16 bytes")
+	}
+	for i := range padded {
+		padded[i] = 0
+	}
 	for i := 0; i < 8; i += 2 {
 		padded[i*2] = tweak[i]
 		padded[i*2+1] = tweak[i+1]
 	}
-	return padded
+}
+
+func kiasuBCEncryptTo(roundKeys *[11][16]byte, tweak, block, state, paddedTweak []byte) error {
+	if len(tweak) != 8 {
+		return errors.New("tweak must be 8 bytes")
+	}
+	if len(block) != 16 {
+		return errors.New("block must be 16 bytes")
+	}
+	if len(state) != 16 {
+		return errors.New("state must be 16 bytes")
+	}
+	if len(paddedTweak) != 16 {
+		return errors.New("padded tweak must be 16 bytes")
+	}
+
+	padTweakTo(tweak, paddedTweak)
+	copy(state, block)
+
+	for i := 0; i < 16; i++ {
+		state[i] ^= roundKeys[0][i] ^ paddedTweak[i]
+	}
+
+	for round := 1; round < 10; round++ {
+		for i := 0; i < 16; i++ {
+			state[i] = sbox[state[i]]
+		}
+		shiftRows(state)
+		mixColumns(state)
+		for i := 0; i < 16; i++ {
+			state[i] ^= roundKeys[round][i] ^ paddedTweak[i]
+		}
+	}
+
+	for i := 0; i < 16; i++ {
+		state[i] = sbox[state[i]]
+	}
+	shiftRows(state)
+	for i := 0; i < 16; i++ {
+		state[i] ^= roundKeys[10][i] ^ paddedTweak[i]
+	}
+
+	return nil
+}
+
+func kiasuBCDecryptTo(roundKeys *[11][16]byte, tweak, block, state, paddedTweak []byte) error {
+	if len(tweak) != 8 {
+		return errors.New("tweak must be 8 bytes")
+	}
+	if len(block) != 16 {
+		return errors.New("block must be 16 bytes")
+	}
+	if len(state) != 16 {
+		return errors.New("state must be 16 bytes")
+	}
+	if len(paddedTweak) != 16 {
+		return errors.New("padded tweak must be 16 bytes")
+	}
+
+	padTweakTo(tweak, paddedTweak)
+	copy(state, block)
+
+	for i := 0; i < 16; i++ {
+		state[i] ^= roundKeys[10][i] ^ paddedTweak[i]
+	}
+	invShiftRows(state)
+	for i := 0; i < 16; i++ {
+		state[i] = invSbox[state[i]]
+	}
+
+	for round := 9; round > 0; round-- {
+		for i := 0; i < 16; i++ {
+			state[i] ^= roundKeys[round][i] ^ paddedTweak[i]
+		}
+		invMixColumns(state)
+		invShiftRows(state)
+		for i := 0; i < 16; i++ {
+			state[i] = invSbox[state[i]]
+		}
+	}
+
+	for i := 0; i < 16; i++ {
+		state[i] ^= roundKeys[0][i] ^ paddedTweak[i]
+	}
+
+	return nil
 }
 
 // KiasuBCEncrypt encrypts a 16-byte block using KIASU-BC with the given key and tweak.
@@ -246,52 +348,13 @@ func KiasuBCEncrypt(key, tweak, block []byte) ([]byte, error) {
 		return nil, errors.New("block must be 16 bytes")
 	}
 
-	// Expand key and pad tweak
-	roundKeys := expandKey(key)
-	paddedTweak := padTweak(tweak)
-
-	// Create state
+	var roundKeys [11][16]byte
+	expandKeyTo(key, &roundKeys)
+	paddedTweak := make([]byte, 16)
 	state := make([]byte, 16)
-	copy(state, block)
-
-	// Initial round
-	for i := 0; i < 16; i++ {
-		state[i] ^= roundKeys[0][i] ^ paddedTweak[i]
+	if err := kiasuBCEncryptTo(&roundKeys, tweak, block, state, paddedTweak); err != nil {
+		return nil, err
 	}
-
-	// Main rounds
-	for round := 1; round < 10; round++ {
-		// SubBytes
-		for i := 0; i < 16; i++ {
-			state[i] = sbox[state[i]]
-		}
-
-		// ShiftRows
-		shiftRows(state)
-
-		// MixColumns
-		mixColumns(state)
-
-		// AddRoundKey
-		for i := 0; i < 16; i++ {
-			state[i] ^= roundKeys[round][i] ^ paddedTweak[i]
-		}
-	}
-
-	// Final round
-	// SubBytes
-	for i := 0; i < 16; i++ {
-		state[i] = sbox[state[i]]
-	}
-
-	// ShiftRows
-	shiftRows(state)
-
-	// AddRoundKey
-	for i := 0; i < 16; i++ {
-		state[i] ^= roundKeys[10][i] ^ paddedTweak[i]
-	}
-
 	return state, nil
 }
 
@@ -307,51 +370,12 @@ func KiasuBCDecrypt(key, tweak, block []byte) ([]byte, error) {
 		return nil, errors.New("block must be 16 bytes")
 	}
 
-	// Expand key and pad tweak
-	roundKeys := expandKey(key)
-	paddedTweak := padTweak(tweak)
-
-	// Create state
+	var roundKeys [11][16]byte
+	expandKeyTo(key, &roundKeys)
+	paddedTweak := make([]byte, 16)
 	state := make([]byte, 16)
-	copy(state, block)
-
-	// Initial round
-	for i := 0; i < 16; i++ {
-		state[i] ^= roundKeys[10][i] ^ paddedTweak[i]
+	if err := kiasuBCDecryptTo(&roundKeys, tweak, block, state, paddedTweak); err != nil {
+		return nil, err
 	}
-
-	// Inverse ShiftRows
-	invShiftRows(state)
-
-	// Inverse SubBytes
-	for i := 0; i < 16; i++ {
-		state[i] = invSbox[state[i]]
-	}
-
-	// Main rounds
-	for round := 9; round > 0; round-- {
-		// AddRoundKey
-		for i := 0; i < 16; i++ {
-			state[i] ^= roundKeys[round][i] ^ paddedTweak[i]
-		}
-
-		// Inverse MixColumns
-		invMixColumns(state)
-
-		// Inverse ShiftRows
-		invShiftRows(state)
-
-		// Inverse SubBytes
-		for i := 0; i < 16; i++ {
-			state[i] = invSbox[state[i]]
-		}
-	}
-
-	// Final round
-	// AddRoundKey
-	for i := 0; i < 16; i++ {
-		state[i] ^= roundKeys[0][i] ^ paddedTweak[i]
-	}
-
 	return state, nil
 }


### PR DESCRIPTION
The ipcrypt functions are great, however they do perform quite a lot of allocations and there are some potential performance optimisations to be gained from doing so.

This PR adds new XXXTo() functions for each of the four modes, (which are used behind the existing API calls), to allow reuse of memory and become zero-allocation.

Results are as follows:

Before the optimizations:
```
goos: darwin
goarch: arm64
pkg: github.com/jedisct1/go-ipcrypt
cpu: Apple M4
BenchmarkModes/DeterministicEncrypt/IPv4-10    	10899565	        95.17 ns/op	     528 B/op	       2 allocs/op
BenchmarkModes/DeterministicEncrypt/IPv6-10    	12816626	        93.47 ns/op	     528 B/op	       2 allocs/op
BenchmarkModes/DeterministicDecrypt/IPv4-10    	12871692	        93.43 ns/op	     528 B/op	       2 allocs/op
BenchmarkModes/DeterministicDecrypt/IPv6-10    	12890138	        93.37 ns/op	     528 B/op	       2 allocs/op
BenchmarkModes/NDEncrypt/IPv4-10               	 3662414	       329.8 ns/op	     504 B/op	       4 allocs/op
BenchmarkModes/NDEncrypt/IPv6-10               	 3548292	       337.9 ns/op	     504 B/op	       4 allocs/op
BenchmarkModes/NDDecrypt/IPv4-10               	  519878	      2346 ns/op	     488 B/op	       4 allocs/op
BenchmarkModes/NDDecrypt/IPv6-10               	  513570	      2363 ns/op	     496 B/op	       4 allocs/op
BenchmarkModes/NDXEncrypt/IPv4-10              	 5270468	       226.7 ns/op	    1120 B/op	       7 allocs/op
BenchmarkModes/NDXEncrypt/IPv6-10              	 5051662	       236.5 ns/op	    1120 B/op	       7 allocs/op
BenchmarkModes/NDXDecrypt/IPv4-10              	 5207691	       230.3 ns/op	    1096 B/op	       7 allocs/op
BenchmarkModes/NDXDecrypt/IPv6-10              	 4929634	       242.6 ns/op	    1104 B/op	       7 allocs/op
BenchmarkModes/PFXEncrypt/IPv4-10              	  675484	      1773 ns/op	    3104 B/op	     132 allocs/op
BenchmarkModes/PFXEncrypt/IPv6-10              	  187581	      6470 ns/op	    9248 B/op	     516 allocs/op
BenchmarkModes/PFXDecrypt/IPv4-10              	  756778	      1596 ns/op	    3104 B/op	     132 allocs/op
BenchmarkModes/PFXDecrypt/IPv6-10              	  202846	      5901 ns/op	    9248 B/op	     516 allocs/op
```
The PFX mode is notably slow for decryption, as it does a lot of allocations.

Afterwards:
```
goos: darwin
goarch: arm64
pkg: github.com/jedisct1/go-ipcrypt
cpu: Apple M4
BenchmarkAllocations/DeterministicEncrypt/IPv4-10    	 9683328	       104.4 ns/op	     528 B/op	       2 allocs/op
BenchmarkAllocations/DeterministicEncrypt/IPv6-10    	11758062	       101.9 ns/op	     528 B/op	       2 allocs/op
BenchmarkAllocations/DeterministicEncryptTo/IPv4-10  	96331054	        12.76 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/DeterministicEncryptTo/IPv6-10  	96211665	        12.74 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/DeterministicDecrypt/IPv4-10    	11532612	       102.8 ns/op	     528 B/op	       2 allocs/op
BenchmarkAllocations/DeterministicDecrypt/IPv6-10    	11747846	       103.4 ns/op	     528 B/op	       2 allocs/op
BenchmarkAllocations/DeterministicDecryptTo/IPv4-10  	96473685	        12.78 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/DeterministicDecryptTo/IPv6-10  	94559234	        12.98 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/NDEncrypt/IPv4-10               	 4494896	       264.9 ns/op	      24 B/op	       1 allocs/op
BenchmarkAllocations/NDEncrypt/IPv6-10               	 4378069	       271.8 ns/op	      24 B/op	       1 allocs/op
BenchmarkAllocations/NDEncryptTo/IPv4-10             	 6718228	       179.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/NDEncryptTo/IPv6-10             	 6710262	       179.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/NDDecrypt/IPv4-10               	  530713	      2268 ns/op	       8 B/op	       1 allocs/op
BenchmarkAllocations/NDDecrypt/IPv6-10               	  533724	      2294 ns/op	      16 B/op	       1 allocs/op
BenchmarkAllocations/NDDecryptTo/IPv4-10             	  562756	      2183 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/NDDecryptTo/IPv6-10             	  547240	      2178 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/NDXEncrypt/IPv4-10              	 4906118	       244.0 ns/op	    1568 B/op	       4 allocs/op
BenchmarkAllocations/NDXEncrypt/IPv6-10              	 4745586	       253.5 ns/op	    1568 B/op	       4 allocs/op
BenchmarkAllocations/NDXEncryptTo/IPv4-10            	36069930	        33.57 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/NDXEncryptTo/IPv6-10            	36468759	        33.34 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/NDXDecrypt/IPv4-10              	 4810798	       248.5 ns/op	    1560 B/op	       5 allocs/op
BenchmarkAllocations/NDXDecrypt/IPv6-10              	 4426274	       266.8 ns/op	    1568 B/op	       5 allocs/op
BenchmarkAllocations/NDXDecryptTo/IPv4-10            	40063990	        29.97 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/NDXDecryptTo/IPv6-10            	40379679	        30.03 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/PFXEncrypt/IPv4-10              	 1335013	       897.1 ns/op	    1552 B/op	       4 allocs/op
BenchmarkAllocations/PFXEncrypt/IPv6-10              	  386245	      3112 ns/op	    1552 B/op	       4 allocs/op
BenchmarkAllocations/PFXEncryptTo/IPv4-10            	 1614217	       744.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/PFXEncryptTo/IPv6-10            	  403288	      3010 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/PFXDecrypt/IPv4-10              	 1626735	       735.7 ns/op	    1552 B/op	       4 allocs/op
BenchmarkAllocations/PFXDecrypt/IPv6-10              	  499734	      2430 ns/op	    1552 B/op	       4 allocs/op
BenchmarkAllocations/PFXDecryptTo/IPv4-10            	 2117570	       569.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllocations/PFXDecryptTo/IPv6-10            	  507560	      2363 ns/op	       0 B/op	       0 allocs/op
```

Note that the performance improvement is pretty dramatic - even the non `To()` functions mostly benefit, with the exception of `deterministic` mode, which becomes very slightly slower.

Full disclosure - I used codex to help with parts of this, particularly the tests. 

Also note that the API signature slightly changed for some of the xxTo() calls; specifically the use of net.IP instead of string as the ip parameter for some functions. Also the `pfx` `To()` functions return a net.IP that is always a 16 byte slice, even for v4. That's because we're reusing the input parameter and if we returned  a slice of only [12:16], which was then reused for a subsequent call, it would fail the size checks. It seems like a good idea to try and avoid that.